### PR TITLE
Make updateIndex() calls asynchronous

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -47,7 +47,7 @@ class Index {
     @param oplog - the source operations log that called updateIndex
     @param entries - operations that were added to the log
   */
-  updateIndex (oplog, entries) {
+  async updateIndex (oplog, entries) {
     this._index = oplog.values
   }
 }


### PR DESCRIPTION
This PR will call Store's internal updateIndex() asynchronously making it possible to do asynchronous processing in the Indexes.

Closes #18 
