### PR TITLE
Feature/keys and permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Haad",
   "license": "MIT",
   "dependencies": {
-      "ipfs-log": "git://github.com/coyotespike/ipfs-log.git#138600d5fec77d2647b7f7e0a1c125129d88af7d",
+      "ipfs-log": "git://github.com/coyotespike/ipfs-log.git#9f192959c05017ba30da2fb4cee893cc048f6fb2",
     "logplease": "^1.2.14",
     "p-each-series": "^1.0.0",
     "readable-stream": "~2.3.5"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Haad",
   "license": "MIT",
   "dependencies": {
-      "ipfs-log": "git://github.com/coyotespike/ipfs-log.git#f67869591275aba7aa81fd71221e99b0ada5ff59",
+    "ipfs-log": "git://github.com/coyotespike/ipfs-log.git#4f3c736224f842f67548caa723dc1616fc6a0014",
     "logplease": "^1.2.14",
     "p-each-series": "^1.0.0",
     "readable-stream": "~2.3.5"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Haad",
   "license": "MIT",
   "dependencies": {
-      "ipfs-log": "git://github.com/coyotespike/ipfs-log.git#9f192959c05017ba30da2fb4cee893cc048f6fb2",
+      "ipfs-log": "git://github.com/coyotespike/ipfs-log.git#f67869591275aba7aa81fd71221e99b0ada5ff59",
     "logplease": "^1.2.14",
     "p-each-series": "^1.0.0",
     "readable-stream": "~2.3.5"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Haad",
   "license": "MIT",
   "dependencies": {
-    "ipfs-log": "~4.1.0",
+      "ipfs-log": "git://github.com/coyotespike/ipfs-log.git#138600d5fec77d2647b7f7e0a1c125129d88af7d",
     "logplease": "^1.2.14",
     "p-each-series": "^1.0.0",
     "readable-stream": "~2.3.5"

--- a/src/Store.js
+++ b/src/Store.js
@@ -422,8 +422,8 @@ class Store {
 
   async _addOperation (data, batchOperation, lastOperation, onProgressCallback) {
     if (this._oplog) {
-      if (!this.access.verify(this._key)) throw new Error("Not allowed to write");
-      const entry = await this._oplog.append(data, this.options.referenceCount)
+      if (!this.access.verifyPermissions(this._key)) throw new Error("Not allowed to write");
+      const entry = await this._oplog.append(data, this.options.referenceCount, this.access.sign)
       this._recalculateReplicationStatus(this.replicationStatus.progress + 1, entry.clock.time)
       await this._cache.set('_localHeads', [entry])
       await this._updateIndex()

--- a/src/Store.js
+++ b/src/Store.js
@@ -232,9 +232,9 @@ class Store {
         return Promise.resolve(null)
       }
 
-      if (!this.access.write.includes(head.key) && !this.access.write.includes('*')) {
         console.warn("Warning: Given input entry is not allowed in this log and was discarded (no write access).")
         return Promise.resolve(null)
+      if (!this.access.verify(head.key)) {
       }
 
       // TODO: verify the entry's signature here
@@ -412,7 +412,6 @@ class Store {
   }
 
   async _addOperation (data, batchOperation, lastOperation, onProgressCallback) {
-    if (this._oplog) {
       const entry = await this._oplog.append(data, this.options.referenceCount)
       this._recalculateReplicationStatus(this.replicationStatus.progress + 1, entry.clock.time)
       await this._cache.set('_localHeads', [entry])
@@ -420,6 +419,7 @@ class Store {
       this.events.emit('write', this.address.toString(), entry, this._oplog.heads)
       if (onProgressCallback) onProgressCallback(entry)
       return entry.hash
+    if (this._oplog && this.access.verify(this._key)) {
     }
   }
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -412,6 +412,8 @@ class Store {
   }
 
   async _addOperation (data, batchOperation, lastOperation, onProgressCallback) {
+    if (this._oplog) {
+      if (!this.access.verify(this._key)) throw new Error("Not allowed to write");
       const entry = await this._oplog.append(data, this.options.referenceCount)
       this._recalculateReplicationStatus(this.replicationStatus.progress + 1, entry.clock.time)
       await this._cache.set('_localHeads', [entry])
@@ -419,7 +421,6 @@ class Store {
       this.events.emit('write', this.address.toString(), entry, this._oplog.heads)
       if (onProgressCallback) onProgressCallback(entry)
       return entry.hash
-    if (this._oplog && this.access.verify(this._key)) {
     }
   }
 


### PR DESCRIPTION
This is the `orbit-db-store` PR designed to work with an `ipfs-log` PR, and a new repo `orbit-db-access-controllers` (which can simply become a PR to `orbit-db` if desired).

This PR uses `verifyPermissions` and `verifyEntries` from the access controllers to perform checks which `ipfs-log` used to perform. That is, these checks occur at the `orbit-db-store` level, leaving `ipfs-log` to sign and add entries.

All integration tests in `orbit-db` continue to pass, as this is a refactor clearing the way for new access controllers.