### PR TITLE
Proto/dynamic access: WIP

### DIFF
--- a/src/Replicator.js
+++ b/src/Replicator.js
@@ -155,7 +155,7 @@ class Replicator extends EventEmitter {
     this._stats.tasksStarted += 1
 
     const exclude = []
-    const log = await Log.fromEntryHash(this._store._ipfs, hash, this._store._oplog.id, batchSize, exclude, this._store.key, this._store.access.write)
+    const log = await Log.fromEntryHash(this._store._ipfs, hash, this._store._oplog.id, batchSize, exclude, this._store.key, this._store.access.write, this.store.verifyEntry, this.store.decorateEntry)
     this._buffer.push(log)
 
     const latest = log.values[0]


### PR DESCRIPTION
This PR rebases the `proto/dynamic-access` branch on `master`, and then adds commits to pass in option `verifyEntry` and `decorateEntry` functions.

It is WIP as we continue to work on permissions across the three repos.

When we are ready to merge, probably should merge `ipfs-log` first as at the moment this PR depends on https://github.com/orbitdb/ipfs-log/pull/126.