### PR TITLE
Replicator _flushTimers clearing

### DIFF
--- a/src/Replicator.js
+++ b/src/Replicator.js
@@ -107,6 +107,11 @@ class Replicator extends EventEmitter {
     }
   }
 
+  stop() {
+    //Clears the queue flusher
+    clearInterval(this._flushTimer)
+  }
+
   _addToQueue (entry) {
     const hash = entry.hash || entry
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -177,6 +177,9 @@ class Store {
     // TODO: afaik we don't use 'closed' event anymore,
     // to be removed in future releases
     this.events.emit('closed', this.address.toString())
+
+    //Clears the queue flusher instatiated at ./Replicator.js:36
+    clearInterval(this._replicator._flushTimer);
     return Promise.resolve()
   }
 
@@ -438,7 +441,7 @@ class Store {
 
   _recalculateReplicationProgress (max) {
     this._replicationStatus.progress = Math.max.apply(null, [
-      this._replicationStatus.progress, 
+      this._replicationStatus.progress,
       this._oplog.length,
       max || 0,
     ])
@@ -447,8 +450,8 @@ class Store {
 
   _recalculateReplicationMax (max) {
     this._replicationStatus.max = Math.max.apply(null, [
-      this._replicationStatus.max, 
-      this._oplog.length, 
+      this._replicationStatus.max,
+      this._oplog.length,
       max || 0,
     ])
   }

--- a/src/Store.js
+++ b/src/Store.js
@@ -150,6 +150,9 @@ class Store {
     if (this.options.onClose)
       await this.options.onClose(this.address.toString())
 
+    //Replicator teardown logic
+    this._replicator.stop();
+
     // Reset replication statistics
     this._replicationStatus.reset()
 
@@ -177,9 +180,6 @@ class Store {
     // TODO: afaik we don't use 'closed' event anymore,
     // to be removed in future releases
     this.events.emit('closed', this.address.toString())
-
-    //Clears the queue flusher instatiated at ./Replicator.js:36
-    clearInterval(this._replicator._flushTimer);
     return Promise.resolve()
   }
 


### PR DESCRIPTION
Hi,

I spot this issue during the shutting down of an application.
Given this snippet as example:
```
/*global require,__dirname*/
const path = require('path')
, process = require('process')
, {setTimeout} = require('timers')
, IPFS = require('ipfs')
, OrbitDB = require('orbit-db')
, wtf = require('wtfnode')
, repo = require(path.resolve(__dirname, 'src', 'store'))
, documentStoreName = 'test';

const ipfs = new IPFS({
  repo,
  'init': true,
  'start': true,
  'EXPERIMENTAL': {
    'pubsub': true
  }
})
, orbitdb = new OrbitDB(ipfs);

ipfs.once('ready', () => {
  orbitdb.docstore(documentStoreName, {
    'indexBy': 'name'
  })
  .then(db => {


    process.on('SIGINT', () => {
      return db.close()
        .then(() => ipfs.stop())
        .then(() => setTimeout(() => {

          wtf.dump();
        }, 5000));
    });

    db.events.once('ready', () => console.info({
      'type': 'model-ready'
    }));

    db.load();
  })
  .then(() => console.info('done'));
});
```
when I try to shutdown this is the situation (I reported also the overall stdout):
```$node test.js 
Swarm listening on /ip4/127.0.0.1/tcp/4003/ws/ipfs/QmRvrTpPReqgY4UZyftPSJBcGtNFuCFPGuQSfspno2MiMd
Swarm listening on /ip4/127.0.0.1/tcp/4002/ipfs/QmRvrTpPReqgY4UZyftPSJBcGtNFuCFPGuQSfspno2MiMd
Swarm listening on /ip4/192.168.98.140/tcp/4002/ipfs/QmRvrTpPReqgY4UZyftPSJBcGtNFuCFPGuQSfspno2MiMd
Swarm listening on /ip4/172.18.0.1/tcp/4002/ipfs/QmRvrTpPReqgY4UZyftPSJBcGtNFuCFPGuQSfspno2MiMd
done
{ type: 'model-ready' }
^C[WTF Node?] open handles:
- File descriptors: (note: stdio always exists)
  - fd 1 (tty) (stdio)
  - fd 2 (tty) (stdio)
- Intervals:
  - (3000 ~ 3 s) (anonymous) @ /home/dario/git/tmp/orbit-test/node_modules/orbit-db-store/src/Replicator.js:36
```

Node isn't stopping and if I try again it complains about the fact that ipfs is already shutted down with this:
```
^C(node:8083) UnhandledPromiseRejectionWarning: Error: Already stopped
    at Function.promisify (/home/dario/git/tmp/orbit-test/node_modules/ipfs/src/core/components/stop.js:13:23)
    at /home/dario/git/tmp/orbit-test/node_modules/promisify-es6/index.js:41:20
    at new Promise (<anonymous>)
    at IPFS.<anonymous> (/home/dario/git/tmp/orbit-test/node_modules/promisify-es6/index.js:35:16)
    at db.close.then (/home/dario/git/tmp/orbit-test/test.js:30:26)
    at <anonymous>
(node:8083) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:8083) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

If I use my branched version the output becames:
```
$node test.js
Swarm listening on /ip4/127.0.0.1/tcp/4003/ws/ipfs/QmRvrTpPReqgY4UZyftPSJBcGtNFuCFPGuQSfspno2MiMd
Swarm listening on /ip4/127.0.0.1/tcp/4002/ipfs/QmRvrTpPReqgY4UZyftPSJBcGtNFuCFPGuQSfspno2MiMd
Swarm listening on /ip4/192.168.98.140/tcp/4002/ipfs/QmRvrTpPReqgY4UZyftPSJBcGtNFuCFPGuQSfspno2MiMd
Swarm listening on /ip4/172.18.0.1/tcp/4002/ipfs/QmRvrTpPReqgY4UZyftPSJBcGtNFuCFPGuQSfspno2MiMd
done
{ type: 'model-ready' }
^C[WTF Node?] open handles:
- File descriptors: (note: stdio always exists)
  - fd 1 (tty) (stdio)
  - fd 2 (tty) (stdio)
```

Hope this will help.

Dario