### PR TITLE
add Table of Contents and update API on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ console.log(db.replicationStatus)
 
   - `load` - (address, heads)
 
-    Emitted before loading the database history. **address** is a string of the OrbitDB address being loaded. **heads** is an array of ipfs-log Entries from which the history is loaded.
+    Emitted before loading the database history. **address** is a string of the OrbitDB address being loaded. **heads** is an array of ipfs-log Entries from which the history is loaded from. **heads** is omitted when this event is emitted as a result of `loadFromSnapshot`.
 
     ```javascript
     db.events.on('load', (address, heads) => ... )
@@ -205,12 +205,12 @@ console.log(db.replicationStatus)
     db.events.on('replicate.progress', (address, hash, entry, progress, total) => ... )
     ```
 
-  - `replicated` - (address, logCount)
+  - `replicated` - (address, count)
 
-    Emitted after the database was synced with an update from a peer database. **address** is a string of the OrbitDB address that emitted the event. **logCount** ...
+    Emitted after the database was synced with an update from a peer database. **address** is a string of the OrbitDB address that emitted the event. **count** number of items replicated. **count** is omitted when this event is emitted as a result of `loadFromSnapshot`.
 
     ```javascript
-    db.events.on('replicated', (address, logCount) => ... )
+    db.events.on('replicated', (address, count) => ... )
     ```
 
   - `write` - (address, entry, heads)

--- a/README.md
+++ b/README.md
@@ -46,23 +46,21 @@ Base class for [orbit-db](https://github.com/orbitdb/orbit-db) data stores. You 
 
 ## API
 
-### constructor(ipfs, peerId, address, options)
+### constructor(ipfs, identity, address, options)
 
-**ipfs** can be an [IPFS](https://github.com/ipfs/js-ipfs) instance or an [IPFS-API](https://github.com/ipfs/js-ipfs) instance. **peerId** is a string identifying the peer, usually the base58 string of the [PeerId](https://github.com/libp2p/js-peer-id#tob58string) of the IPFS instance. **address** is the OrbitDB address to be used for the store.
+**ipfs** can be an [IPFS](https://github.com/ipfs/js-ipfs) instance or an [IPFS-API](https://github.com/ipfs/js-ipfs) instance. **identity** is an instance of [Identity](https://github.com/orbitdb/orbit-db-identity-provider/). **address** is the OrbitDB address to be used for the store.
 
 `options` is an object with the following required properties:
 
 - `cache`: A [Cache](https://github.com/orbitdb/orbit-db-cache) instance to use for storing heads and snapshots.
 - `Index` : By default it uses an instance of [Index](https://github.com/orbitdb/orbit-db-store/blob/master/src/Index.js).
-- `keystore`: A [Keystore](https://github.com/orbitdb/orbit-db-keystore) instance to use for key management.
 
 the following properties are optional:
 
 - `maxHistory` (Integer): The number of entries to load (Default: `-1`).
 - `referenceCount` (Integer): The number of previous ipfs-log entries a new entry should reference (Default: `64`).
 - `replicationConcurrency` (Integer): The number of concurrent replication processes (Default: `128`).
-- `key`: A [KeyPair](https://github.com/indutny/elliptic/blob/master/lib/elliptic/ec/key.js#L8) instance. By default the provided keystore is used to find an existing KeyPair for the given `peerId`, otherwise a new KeyPair will be created using the given `peerId`.
-- `accessController` (Object): By default only the owner will have write access.
+- `accessController` (Object): An instance of AccessController with the following [interface](https://github.com/orbitdb/orbit-db-access-controllers/blob/master/src/access-controller-interface.js). See [orbit-db-access-controllers](https://github.com/orbitdb/orbit-db-access-controllers) for more information on how to create custom access controllers. By default only the owner will have write access.
 - `onClose` (Function): A function to be called with a string of the OrbitDB address of the database that is closing.
 
 ### Public methods

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:browser": "npm run build:tests && mocha-headless-chrome -f ./test/browser/index.html -a no-sandbox",
     "build": "npm run build:dist",
     "build:dist": "webpack --config ./conf/webpack.config.js --display-modules --sort-modules-by size --mode production",
+    "build:docs": "markdown-toc --no-first1 -i README.md",
     "build:tests": "webpack --config ./conf/webpack.tests.config.js --mode production",
     "lint": "standard"
   },
@@ -45,6 +46,7 @@
     "@babel/runtime": "^7.4.5",
     "babel-loader": "~8.0.4",
     "json-loader": "~0.5.7",
+    "markdown-toc": "^1.2.0",
     "mocha": "^6.2.0",
     "mocha-headless-chrome": "^2.0.3",
     "orbit-db-cache": "~0.3.0",

--- a/src/Store.js
+++ b/src/Store.js
@@ -21,7 +21,6 @@ const DefaultOptions = {
   Index: Index,
   maxHistory: -1,
   fetchEntryTimeout: null,
-  replicate: true,
   referenceCount: 32,
   replicationConcurrency: 128,
   syncLocal: false,
@@ -227,9 +226,13 @@ class Store {
     this._cache = this.options.cache
   }
 
-  async load (amount, { fetchEntryTimeout } = {}) {
+  async load (amount, opts = {}) {
+    if (typeof amount === 'object') {
+      opts = amount
+      amount = undefined
+    }
     amount = amount || this.options.maxHistory
-    fetchEntryTimeout = fetchEntryTimeout || this.options.fetchEntryTimeout
+    const fetchEntryTimeout = opts.fetchEntryTimeout || this.options.fetchEntryTimeout
 
     if (this.options.onLoad) {
       await this.options.onLoad(this)
@@ -380,7 +383,7 @@ class Store {
       await this.options.onLoad(this)
     }
 
-    this.events.emit('load', this.address.toString()) //TODO: inconsistent params
+    this.events.emit('load', this.address.toString()) // TODO emits inconsistent params, missing heads param
 
     const maxClock = (res, val) => Math.max(res, val.clock.time)
 
@@ -476,7 +479,7 @@ class Store {
         const log = await Log.fromJSON(this._ipfs, this.identity, snapshotData, { access: this.access, sortFn: this.options.sortFn, length: -1, timeout: 1000, onProgressCallback: onProgress })
         await this._oplog.join(log)
         await this._updateIndex()
-        this.events.emit('replicated', this.address.toString()) //TODO: inconsistent params, line 116
+        this.events.emit('replicated', this.address.toString()) // TODO: inconsistent params, count param not emited
       }
       this.events.emit('ready', this.address.toString(), this._oplog.heads)
     } else {

--- a/src/Store.js
+++ b/src/Store.js
@@ -476,7 +476,7 @@ class Store {
         const log = await Log.fromJSON(this._ipfs, this.identity, snapshotData, { access: this.access, sortFn: this.options.sortFn, length: -1, timeout: 1000, onProgressCallback: onProgress })
         await this._oplog.join(log)
         await this._updateIndex()
-        this.events.emit('replicated', this.address.toString())
+        this.events.emit('replicated', this.address.toString()) //TODO: inconsistent params, line 116
       }
       this.events.emit('ready', this.address.toString(), this._oplog.heads)
     } else {

--- a/src/Store.js
+++ b/src/Store.js
@@ -476,7 +476,7 @@ class Store {
         const log = await Log.fromJSON(this._ipfs, this.identity, snapshotData, { access: this.access, sortFn: this.options.sortFn, length: -1, timeout: 1000, onProgressCallback: onProgress })
         await this._oplog.join(log)
         await this._updateIndex()
-        this.events.emit('replicated', this.address.toString()) //TODO: inconsistent params, line 116
+        this.events.emit('replicated', this.address.toString())
       }
       this.events.emit('ready', this.address.toString(), this._oplog.heads)
     } else {

--- a/src/Store.js
+++ b/src/Store.js
@@ -380,7 +380,7 @@ class Store {
       await this.options.onLoad(this)
     }
 
-    this.events.emit('load', this.address.toString())
+    this.events.emit('load', this.address.toString()) //TODO: inconsistent params
 
     const maxClock = (res, val) => Math.max(res, val.clock.time)
 
@@ -476,7 +476,7 @@ class Store {
         const log = await Log.fromJSON(this._ipfs, this.identity, snapshotData, { access: this.access, sortFn: this.options.sortFn, length: -1, timeout: 1000, onProgressCallback: onProgress })
         await this._oplog.join(log)
         await this._updateIndex()
-        this.events.emit('replicated', this.address.toString())
+        this.events.emit('replicated', this.address.toString()) //TODO: inconsistent params, line 116
       }
       this.events.emit('ready', this.address.toString(), this._oplog.heads)
     } else {


### PR DESCRIPTION
Update README with documentation for missing constructor (and options), public methods, and events. In addition, corrects a few event params and uniformly uses `address` to reference the OrbitDB address (instead of inconsistent usage of both `dbname` & `address`).

**Edit**: I have removed two `defaultOptions` properties (`path` & `replicate`) that don't appear to be used. In addition, I have removed the `onProgressCallback` param passed to `loadFromSnapshot()` that was never used.

I've also noticed that a couple events emit inconsistent params.

- `load` : 
https://github.com/orbitdb/orbit-db-store/blob/84aa8095c0d08fc428b8c375aa83cb7fe873bc2d/src/Store.js#L207
https://github.com/orbitdb/orbit-db-store/blob/84aa8095c0d08fc428b8c375aa83cb7fe873bc2d/src/Store.js#L313
- `replicated` : 
https://github.com/orbitdb/orbit-db-store/blob/84aa8095c0d08fc428b8c375aa83cb7fe873bc2d/src/Store.js#L116
https://github.com/orbitdb/orbit-db-store/blob/84aa8095c0d08fc428b8c375aa83cb7fe873bc2d/src/Store.js#L403


Is this desired? or should I update to have matching params?

#### TODO
- [x] document constructor options
- [ ] loadMoreFrom description
- [x] replicated event description
- [x] closed event description
- [x] ready event description
- [x] load event description 

**New scripts**:
 - `npm run build:docs/tocs` : generates a table of contents for README.md

**New dev dependencies**:
- `markdown-toc`: generates a markdown table of contents 

Fixes #26 