### PR TITLE
Resolve `sync` only after heads have been added

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -263,17 +263,13 @@ class Store {
         .then(() => head)
     }
 
-    await mapSeries(heads, saveToIpfs)
-      .then(async (saved) => {
-        this._replicator.load(saved.filter(e => e !== null))
-      })
+    const saved = await mapSeries(heads, saveToIpfs)
+    await this._replicator.load(saved.filter(e => e !== null))
 
     return new Promise(resolve => {
-      this.events.on('replicate.progress', (_x, _y, _z, progress, have) => {
+      this.events.on('replicate.progress', (address, hash, entry, progress, have) => {
         if (progress === have) {
-          this.events.on('replicated', () => {
-            resolve()
-          })
+          this.events.on('replicated', resolve)
         }
       })
       if (!this._replicator._buffer.length && !Object.values(this._replicator._queue).length) {


### PR DESCRIPTION
This is required for a tentative solution to https://github.com/orbitdb/orbit-db/issues/509:

https://github.com/orbitdb/orbit-db/pull/514

See [this commit message](https://github.com/orbitdb/orbit-db-store/pull/38/commits/ddac2ad7dbd4e57c1045237255b653eda10d8910) for a more detailed explanation.