### PR TITLE
Return raw _index for all store types.

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -122,9 +122,7 @@ class Store {
   }
 
   get all () {
-    return Array.isArray(this._index._index)
-      ? this._index._index
-      : Object.keys(this._index._index).map(e => this._index._index[e])
+    return this._index._index
   }
 
   get type () {


### PR DESCRIPTION
Tested against all bundled stores; eventlog, kvstore, counter, docstore, feed. Some stores such as eventlog will only return the latest record hash but can be retrieved using the iterator method.