### PR TITLE
Create basic implementation for _addOperationBatch

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -426,8 +426,23 @@ class Store {
     }
   }
 
-  _addOperationBatch (data, batchOperation, lastOperation, onProgressCallback) {
-    throw new Error('Not implemented!')
+  async _addOperationBatch (data, batchOperation, lastOperation, onProgressCallback) {
+
+    if (this._oplog) {
+      const entry = await this._oplog.append(data, this.options.referenceCount)
+      this._recalculateReplicationStatus(this.replicationStatus.progress + 1, entry.clock.time)
+
+      if (lastOperation) {
+        await this._cache.set('_localHeads', [entry])
+        await this._updateIndex()
+      }
+
+      this.events.emit('write', this.address.toString(), entry, this._oplog.heads)
+      if (onProgressCallback) onProgressCallback(entry)
+      return entry.cid
+
+    }
+
   }
 
   _onLoadProgress (cid, entry, progress, total) {


### PR DESCRIPTION
I was trying to use the "batchPut" function in orbit-db-docstore but noticed that this method wasn't implemented yet. 

Rebuilding the index seemed like it was probably the most expensive part, so I saved it for the last operation. I wasn't sure if there were any other intended optimizations. I wasn't sure what to do the with "batchOperation" variable that is passed in. I'm also not sure if "_localHeads" should be set every iteration or just the last one. 