### PR TITLE
Adding index function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-store",
-  "version": "2.6.0-rc.2",
+  "version": "2.6.0-rc3",
   "description": "Base class for orbit-db data stores",
   "main": "src/Store.js",
   "scripts": {

--- a/src/Store.js
+++ b/src/Store.js
@@ -127,6 +127,10 @@ class Store {
       : Object.keys(this._index._index).map(e => this._index._index[e])
   }
 
+  get index () {
+    return this._index._index
+  }
+
   get type () {
     return this._type
   }


### PR DESCRIPTION
This PR adds an `index` getter to the store that simply returns `db._index._index`. The direct property access is used quite regularly in OrbitDB development

While this _may_ supercede `db.all()`, the `all` function is kept to reduce friction and support existing applications.