### PR TITLE
Default referenceCount from 64 to 32

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -18,7 +18,7 @@ const DefaultOptions = {
   maxHistory: -1,
   directory: './orbitdb',
   replicate: true,
-  referenceCount: 64,
+  referenceCount: 32,
   replicationConcurrency: 128
 }
 


### PR DESCRIPTION
This PR simply reduces the default referenceCount from 64 to 32, which gives a substaintial gain in append performance due to less IPLD traversal.