### PR TITLE
Add setIdentity Method

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -60,7 +60,7 @@ class Store {
     this._oplog = new Log(this._ipfs, this.identity, { logId: this.id, access: this.access, sortFn: this.options.sortFn })
 
     // Create the index
-    this._index = new this.options.Index(this.identity.publicKey)
+    this._index = new this.options.Index(this.address.root)
 
     // Replication progress info
     this._replicationStatus = new ReplicationInfo()
@@ -149,6 +149,11 @@ class Store {
     return this._replicationStatus
   }
 
+  setIdentity (identity) {
+    this.identity = identity
+    this._oplog.setIdentity(identity)
+  }
+
   async close () {
     if (this.options.onClose) {
       await this.options.onClose(this.address.toString())
@@ -195,7 +200,7 @@ class Store {
     await this.close()
     await this._cache.destroy()
     // Reset
-    this._index = new this.options.Index(this.identity.publicKey)
+    this._index = new this.options.Index(this.address.root)
     this._oplog = new Log(this._ipfs, this.identity, { logId: this.id, access: this.access, sortFn: this.options.sortFn })
     this._cache = this.options.cache
   }


### PR DESCRIPTION
This PR adds a new method to the base store class for setting the identity to be used. It currently relies on an unreleased feature in ipfs-log. https://github.com/orbitdb/ipfs-log/pull/260

Looks like there are no tests for this library :) 