### PR TITLE
onLoad on loadFromSnapshot

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -335,6 +335,10 @@ class Store {
   }
 
   async loadFromSnapshot (onProgressCallback) {
+    if (this.options.onLoad) {
+      await this.options.onLoad(this)
+    }
+
     this.events.emit('load', this.address.toString())
 
     const maxClock = (res, val) => Math.max(res, val.clock.time)


### PR DESCRIPTION
This PR adds the calling of onLoad into `Store.loadFromSnapshot` since `loadFromSnapshot` expects the cache to be open.