### PR TITLE
Remove all 'peer' event listeners on close

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -187,6 +187,8 @@ class Store {
     this.events.removeAllListeners('replicated')
     this.events.removeAllListeners('ready')
     this.events.removeAllListeners('write')
+    this.events.removeAllListeners('peer')
+
 
     // Database is now closed
     // TODO: afaik we don't use 'closed' event anymore,

--- a/src/Store.js
+++ b/src/Store.js
@@ -189,7 +189,6 @@ class Store {
     this.events.removeAllListeners('write')
     this.events.removeAllListeners('peer')
 
-
     // Database is now closed
     // TODO: afaik we don't use 'closed' event anymore,
     // to be removed in future releases


### PR DESCRIPTION
Fixes a possible memory leak if the `peer` event listeners aren't removed on database close