### PR TITLE
Upgrade to new ipfs-log

### DIFF
--- a/src/Replicator.js
+++ b/src/Replicator.js
@@ -113,6 +113,10 @@ class Replicator extends EventEmitter {
   stop () {
     // Clears the queue flusher
     clearInterval(this._flushTimer)
+    // Remove event listeners
+    this.removeAllListeners('load.added')
+    this.removeAllListeners('load.end')
+    this.removeAllListeners('load.progress')
   }
 
   _addToQueue (entry) {

--- a/src/Store.js
+++ b/src/Store.js
@@ -291,7 +291,7 @@ class Store {
       const logEntry = Object.assign({}, head)
       logEntry.hash = null
       const codec = logEntry.v === 0 ? 'dag-pb' : 'dag-cbor'
-      const hash = await dagNode.write(this._ipfs, codec, logEntry, { links: ['next'], onlyHash: true })
+      const hash = await dagNode.write(this._ipfs, codec, logEntry, { links: ['next', 'refs'], onlyHash: true })
 
       if (hash !== head.hash) {
         console.warn('"WARNING! Head hash didn\'t match the contents')


### PR DESCRIPTION
This PR upgrades to the latest ipfs-log.

- Fetch the log as per new ipfs-log
- Remove event listeners from replicator when stopped