### PR TITLE
onEmpty -> onIdle

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -170,7 +170,7 @@ class Store {
       await this.options.onClose(this)
     }
 
-    await this._opqueue.onEmpty()
+    await this._opqueue.onIdle()
 
     // Replicator teardown logic
     this._replicator.stop()


### PR DESCRIPTION
This pr fixes a mistake i made in https://github.com/orbitdb/orbit-db-store/pull/85

As seen here https://github.com/sindresorhus/p-queue#onempty and comparing onEmpty and onIdle:

**.onEmpty** will resolve when the *queue* is emptied, or when the last promise in the queue has been called.
**.onIdle** will resolve when the *queue* is completely done, or when the last promise in the queue has been called and has resolved.

.onIdle is the behavior I thought .onEmpty had but recently I looked at p-queue again and saw the difference.

the issue with using onEmpty here is we could still see some errors it was brought into prevent. onIdle would cover these cases where orbitdb closes the cache before the last _addOperation call in queue has resolved.

This pr changes the `await this._opqueue.onEmpty()` line in the close method to `await this._opqueue.onIdle()` so that the store does not close until the queue is emptied and all _addOperations are resolved.