### PR TITLE
Removing streams from snapshot functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@
 version: 2.1
 
 executors:
-  node10-browsers:
+  node12-browsers:
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
 
 jobs:
   setup:
-    executor: node10-browsers
+    executor: node12-browsers
     steps:
       - checkout
       - run: mkdir -p /tmp/workspace
@@ -25,19 +25,19 @@ jobs:
             - conf
             - package.json
   test-node:
-    executor: node10-browsers
+    executor: node12-browsers
     steps:
       - attach_workspace:
           at: ./
       - run: npm run test:node
   test-browser:
-    executor: node10-browsers
+    executor: node12-browsers
     steps:
       - attach_workspace:
           at: ./
       - run: npm run test:browser
   build:
-    executor: node10-browsers
+    executor: node12-browsers
     steps:
       - attach_workspace:
           at: ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-store",
-  "version": "4.0.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1631,22 +1631,6 @@
             "@hapi/pinpoint": "^1.0.2",
             "@hapi/topo": "^3.1.3"
           }
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
         }
       }
     },
@@ -3577,6 +3561,15 @@
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
           "dev": true
         },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -3585,6 +3578,12 @@
           "requires": {
             "glob": "^7.1.3"
           }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
         }
       }
     },
@@ -5086,9 +5085,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.564",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.564.tgz",
-      "integrity": "sha512-fNaYN3EtKQWLQsrKXui8mzcryJXuA0LbCLoizeX6oayG2emBaS5MauKjCPAvc29NEY4FpLHIUWiP+Y0Bfrs5dg==",
+      "version": "1.3.565",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.565.tgz",
+      "integrity": "sha512-me5dGlHFd8Q7mKhqbWRLIYnKjw4i0fO6hmW0JBxa7tM87fBfNEjWokRnDF7V+Qme/9IYpwhfMn+soWs40tXWqg==",
       "dev": true
     },
     "elliptic": {
@@ -6846,16 +6845,6 @@
             "which": "^1.2.9"
           }
         },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -6864,12 +6853,6 @@
           "requires": {
             "isexe": "^2.0.0"
           }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
         }
       }
     },
@@ -10168,9 +10151,9 @@
           "dev": true
         },
         "merge-options": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.1.tgz",
-          "integrity": "sha512-PZAJhpYGQhb51rYIXEYysFmpAmEu49Zq6XEMw2rRcLaCOkLiA6kM7Hm23K5EamRjSEmYZfIGcsndxEjzsrJfGg==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.2.tgz",
+          "integrity": "sha512-7TM9KD5J6TfT7Frs7PUnhA7Agkuag/vG9BdDbFtP54mrquqflOTJ30QXzlpI/ZX2cLDi6lw96eRF3ZhxkUVgKw==",
           "dev": true,
           "requires": {
             "is-plain-obj": "^2.1.0"
@@ -13899,12 +13882,13 @@
       }
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "ltgt": {
@@ -14434,6 +14418,14 @@
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
       }
     },
     "minizlib": {
@@ -14713,18 +14705,18 @@
       }
     },
     "mongodb-memory-server": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.7.2.tgz",
-      "integrity": "sha512-isWtb1HM8z9wdLgOe4YZJjJGPRsDQfPh4X1cJfdUJcdRDl0A5Ullck6Yby2JYnTH9SFQaUePhi4RQnmQW98eNQ==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.7.4.tgz",
+      "integrity": "sha512-VucLjrv6PBzmz36KlReBv62uPg4JkAywHvDHUXO/LXtAroWcH7HjECbCSTlwJIhGwpWcoeuZstlsrgu2btsn7A==",
       "dev": true,
       "requires": {
-        "mongodb-memory-server-core": "6.7.2"
+        "mongodb-memory-server-core": "6.7.4"
       }
     },
     "mongodb-memory-server-core": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.7.2.tgz",
-      "integrity": "sha512-SZ2Nw+4xZvRJ9r2q3mcE0rf8fz8u5FP1qvFydom6Q1VfDGR+rlunVPw/raw2JvuprbkxzpA1RQSiutnk4YLnCQ==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.7.4.tgz",
+      "integrity": "sha512-jvlx5+OUpJOagSyQXHHH/HhT63cJtdN5yruvSrjQ5Ivfq1lITI7fq6vTxZe4USlGoygqQiJN+MX8b1JYX2sLnw==",
       "dev": true,
       "requires": {
         "@types/tmp": "^0.2.0",
@@ -14738,9 +14730,9 @@
         "lockfile": "^1.0.4",
         "md5-file": "^5.0.0",
         "mkdirp": "^1.0.4",
-        "mongodb": "3.6.1",
+        "mongodb": "3.6.2",
         "semver": "^7.3.2",
-        "tar-stream": "^2.1.3",
+        "tar-stream": "^2.1.4",
         "tmp": "^0.2.1",
         "uuid": "8.3.0",
         "yauzl": "^2.10.0"
@@ -14753,17 +14745,6 @@
           "dev": true,
           "requires": {
             "debug": "4"
-          }
-        },
-        "bl": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-          "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
           }
         },
         "camelcase": {
@@ -14835,21 +14816,6 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         },
-        "mongodb": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.1.tgz",
-          "integrity": "sha512-uH76Zzr5wPptnjEKJRQnwTsomtFOU/kQEU8a9hKHr2M7y9qVk7Q4Pkv0EQVp88742z9+RwvsdTw6dRjDZCNu1g==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "bl": "^2.2.0",
-            "bson": "^1.1.4",
-            "denque": "^1.4.1",
-            "require_optional": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "saslprep": "^1.0.0"
-          }
-        },
         "p-locate": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -14874,55 +14840,11 @@
             "find-up": "^4.0.0"
           }
         },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true,
-              "optional": true
-            }
-          }
         },
         "uuid": {
           "version": "8.3.0",
@@ -15582,6 +15504,12 @@
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.3"
           }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
         }
       }
     },
@@ -20411,9 +20339,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-store",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1032,9 +1032,9 @@
       }
     },
     "@ethersproject/abi": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.3.tgz",
-      "integrity": "sha512-fSSs4sgaf5R1955QSpYXW2YkrYBgyOSyENyyMEyJwxTsKJKQPaReTQXafyeRc8ZLi3/2uzeqakH09r0S1hlFng==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.4.tgz",
+      "integrity": "sha512-T8woaIQHCJMZDAQim1vSp8ycsP2h1/TlnBHzQqR9atKknoqLiT26Wxr9AkhW1aufexkWrZTHbf2837469uS6Eg==",
       "requires": {
         "@ethersproject/address": "^5.0.3",
         "@ethersproject/bignumber": "^5.0.6",
@@ -1340,9 +1340,9 @@
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.3.tgz",
-      "integrity": "sha512-cqsAAFUQV6iWqfgLL7KCPNfd3pXJPDdYtE6QuBEAIpc7cgbJ7TIDCF/dN+1otfERHJIbjGSNrhh4axKRnSFswg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.4.tgz",
+      "integrity": "sha512-QvS5CzxmL46D9Y3OlddurYgEIi5mb0eAgrKm5pM074Uz/1qxCYr+Ah12I4hpaciZtCq4Fe12YWZqUFb1vGcH6Q==",
       "requires": {
         "@ethersproject/address": "^5.0.3",
         "@ethersproject/bignumber": "^5.0.6",
@@ -1388,9 +1388,9 @@
       }
     },
     "@ethersproject/web": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.4.tgz",
-      "integrity": "sha512-1ZSbFGJo61huhDW5M8hqjP8zoCK6zZlu3jYAJrFKVNgBjEm1UYMY5fsoogYHWkLgCgBIf+M6yKzYdtAs4tol4Q==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.5.tgz",
+      "integrity": "sha512-3lffVNOKv/ypW42eY0xhc+UXF+lFUgP1QfIZhWDTJ4xSY6tuNayXKXYq+AqjLXwxwIHzD0TOpe4j46IXJx2NXA==",
       "requires": {
         "@ethersproject/base64": "^5.0.3",
         "@ethersproject/bytes": "^5.0.4",
@@ -1412,312 +1412,426 @@
       }
     },
     "@hapi/accept": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
-      "integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
+      "integrity": "sha512-soThGB+QMgfxlh0Vzhzlf3ZOEOPk5biEwcOXhkF0Eedqx8VnhGiggL9UYHrIsOb1rUg3Be3K8kp0iDL2wbVSOQ==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/address": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
-      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
+      "dev": true
     },
     "@hapi/ammo": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
-      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.2.tgz",
+      "integrity": "sha512-ej9OtFmiZv1qr45g1bxEZNGyaR4jRpyMxU6VhbxjaYThymvOwsyIsUKMZnP5Qw2tfYFuwqCJuIBHGpeIbdX9gQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/b64": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
-      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
+      "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/boom": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
-      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+      "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/bounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
-      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.2.tgz",
+      "integrity": "sha512-3bnb1AlcEByFZnpDIidxQyw1Gds81z/1rSqlx4bIEE+wUN0ATj0D49B5cE1wGocy90Rp/de4tv7GjsKd5RQeew==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "^8.3.1"
       }
     },
     "@hapi/bourne": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
       "dev": true
     },
     "@hapi/call": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
-      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.3.tgz",
+      "integrity": "sha512-5DfWpMk7qZiYhvBhM5oUiT4GQ/O8a2rFR121/PdwA/eZ2C1EsuD547ZggMKAR5bZ+FtxOf0fdM20zzcXzq2mZA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/catbox": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
-      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.3.tgz",
+      "integrity": "sha512-kN9hXO4NYyOHW09CXiuj5qW1syc/0XeVOBsNNk0Tz89wWNQE5h21WF+VsfAw3uFR8swn/Wj3YEVBnWqo82m/JQ==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/podium": "4.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x",
+        "@hapi/podium": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "dev": true,
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/catbox-memory": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
-      "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
+      "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/content": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
-      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.1.tgz",
+      "integrity": "sha512-3TWvmwpVPxFSF3KBjKZ8yDqIKKZZIm7VurDSweYpXYENZrJH3C1hd1+qEQW9wQaUaI76pPBLGrXl6I3B7i3ipA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "7.x.x"
       }
     },
     "@hapi/cryptiles": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
-      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
+      "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "7.x.x"
       }
     },
     "@hapi/file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
-      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
+      "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ==",
       "dev": true
     },
     "@hapi/formula": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==",
       "dev": true
     },
     "@hapi/hapi": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.0.tgz",
-      "integrity": "sha512-Wh0tIDFsl7nemU2JQYW4zZVr9XkpuZ1eM3yaX8tzaYdaYXon8QeB5NzrTNQY3R1/+fO7amQUrOoLLNPRwIZfgw==",
+      "version": "18.4.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.1.tgz",
+      "integrity": "sha512-9HjVGa0Z4Qv9jk9AVoUdJMQLA+KuZ+liKWyEEkVBx3e3H1F0JM6aGbPkY9jRfwsITBWGBU2iXazn65SFKSi/tg==",
       "dev": true,
       "requires": {
-        "@hapi/accept": "^5.0.1",
-        "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/call": "8.x.x",
-        "@hapi/catbox": "^11.1.1",
-        "@hapi/catbox-memory": "5.x.x",
-        "@hapi/heavy": "^7.0.1",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/mimos": "5.x.x",
-        "@hapi/podium": "^4.1.1",
-        "@hapi/shot": "^5.0.1",
-        "@hapi/somever": "3.x.x",
-        "@hapi/statehood": "^7.0.3",
-        "@hapi/subtext": "^7.0.3",
-        "@hapi/teamwork": "5.x.x",
-        "@hapi/topo": "5.x.x",
-        "@hapi/validate": "^1.1.0"
+        "@hapi/accept": "^3.2.4",
+        "@hapi/ammo": "^3.1.2",
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/call": "^5.1.3",
+        "@hapi/catbox": "10.x.x",
+        "@hapi/catbox-memory": "4.x.x",
+        "@hapi/heavy": "6.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "15.x.x",
+        "@hapi/mimos": "4.x.x",
+        "@hapi/podium": "3.x.x",
+        "@hapi/shot": "4.x.x",
+        "@hapi/somever": "2.x.x",
+        "@hapi/statehood": "6.x.x",
+        "@hapi/subtext": "^6.1.3",
+        "@hapi/teamwork": "3.x.x",
+        "@hapi/topo": "3.x.x"
       }
     },
     "@hapi/heavy": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
-      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.2.tgz",
+      "integrity": "sha512-PY1dCCO6dsze7RlafIRhTaGeyTgVe49A/lSkxbhKGjQ7x46o/OFf7hLiRqTCDh3atcEKf6362EaB3+kTUbCsVA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "dev": true,
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/hoek": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
       "dev": true
     },
     "@hapi/inert": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-6.0.2.tgz",
-      "integrity": "sha512-cq0a8jstkLW1+oJaw4jp52PZBEkVbX9d0YDy5aOs3rOKYSjpzs2nQBahnCHEMchOrOSUffLpE+IDoivYHcx8uA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.2.tgz",
+      "integrity": "sha512-8IaGfAEF8SwZtpdaTq0G3aDPG35ZTfWKjnMNniG2N3kE+qioMsBuImIGxna8TNQ+sYMXYK78aqmvzbQHno8qSQ==",
       "dev": true,
       "requires": {
-        "@hapi/ammo": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x",
-        "lru-cache": "5.x.x"
+        "@hapi/ammo": "3.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x",
+        "lru-cache": "4.1.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "dev": true,
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "@hapi/iron": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
-      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
+      "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
       "dev": true,
       "requires": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/b64": "4.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/cryptiles": "4.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
       }
     },
     "@hapi/mimos": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
-      "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
+      "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x",
+        "@hapi/hoek": "8.x.x",
         "mime-db": "1.x.x"
       }
     },
     "@hapi/nigel": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
-      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
+      "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/vise": "^4.0.0"
+        "@hapi/hoek": "8.x.x",
+        "@hapi/vise": "3.x.x"
       }
     },
     "@hapi/pez": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
-      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.2.tgz",
+      "integrity": "sha512-8zSdJ8cZrJLFldTgwjU9Fb1JebID+aBCrCsycgqKYe0OZtM2r3Yv3aAwW5z97VsZWCROC1Vx6Mdn4rujh5Ktcg==",
       "dev": true,
       "requires": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/nigel": "4.x.x"
+        "@hapi/b64": "4.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/content": "^4.1.1",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/nigel": "3.x.x"
       }
     },
     "@hapi/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==",
       "dev": true
     },
     "@hapi/podium": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.1.tgz",
-      "integrity": "sha512-jh7a6+5Z4FUWzx8fgmxjaAa1DTBu+Qfg+NbVdo0f++rE5DgsVidUYrLDp3db65+QjDLleA2MfKQXkpT8ylBDXA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.3.tgz",
+      "integrity": "sha512-QJlnYLEYZWlKQ9fSOtuUcpANyoVGwT68GA9P0iQQCAetBK0fI+nbRBt58+aMixoifczWZUthuGkNjqKxgPh/CQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/teamwork": "5.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "dev": true,
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/shot": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.3.tgz",
-      "integrity": "sha512-qbccs8KL4YSL9x0J/17Z6Udmtrrn32ieGbrCW8iivl2ha8YzlDy9Wvv1pFKh3mzbTsomWHGLF3UsKcQFk/BqPg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.2.tgz",
+      "integrity": "sha512-6LeHLjvsq/bQ0R+fhEyr7mqExRGguNTrxFZf5DyKe3CK6pNabiGgYO4JVFaRrLZ3JyuhkS0fo8iiRE2Ql2oA/A==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "dev": true,
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/somever": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
-      "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
+      "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
       "dev": true,
       "requires": {
-        "@hapi/bounce": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/bounce": "1.x.x",
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/statehood": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
-      "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.2.tgz",
+      "integrity": "sha512-pYXw1x6npz/UfmtcpUhuMvdK5kuOGTKcJNfLqdNptzietK2UZH5RzNJSlv5bDHeSmordFM3kGItcuQWX2lj2nQ==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/iron": "6.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/cryptiles": "4.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/iron": "5.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "dev": true,
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/subtext": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
-      "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.3.tgz",
+      "integrity": "sha512-qWN6NbiHNzohVcJMeAlpku/vzbyH4zIpnnMPMPioQMwIxbPFKeNViDCNI6fVBbMPBiw/xB4FjqiJkRG5P9eWWg==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/file": "2.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/pez": "^5.0.1",
-        "@hapi/wreck": "17.x.x"
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/content": "^4.1.1",
+        "@hapi/file": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/pez": "^4.1.2",
+        "@hapi/wreck": "15.x.x"
       }
     },
     "@hapi/teamwork": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
-      "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
+      "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ==",
       "dev": true
     },
     "@hapi/topo": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/hoek": "^8.3.0"
       }
     },
     "@hapi/validate": {
@@ -1728,26 +1842,43 @@
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
+          "dev": true
+        },
+        "@hapi/topo": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        }
       }
     },
     "@hapi/vise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
-      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
+      "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/wreck": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
-      "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
+      "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@protobufjs/aspromise": {
@@ -1904,52 +2035,16 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/cross-spawn": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.2.tgz",
-      "integrity": "sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
       "dev": true
     },
-    "@types/dedent": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@types/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==",
-      "dev": true
-    },
-    "@types/find-cache-dir": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-      "integrity": "sha512-+JeT9qb2Jwzw72WdjU+TSvD5O1QRPWCeRpDJV+guiIq+2hwR0DFGw+nZNbTFjMIVe6Bf4GgAKeB/6Ytx6+MbeQ==",
-      "dev": true
-    },
-    "@types/find-package-json": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/find-package-json/-/find-package-json-1.1.1.tgz",
-      "integrity": "sha512-XMCocYkg6VUpkbOQMKa3M5cgc3MvU/LJKQwd3VUJrWZbLr2ARUggupsCAF8DxjEEIuSO6HlnH+vl+XV4bgVeEQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-      "dev": true
-    },
-    "@types/lockfile": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.1.tgz",
-      "integrity": "sha512-65WZedEm4AnOsBDdsapJJG42MhROu3n4aSSiu87JXF/pSdlubxZxp3S1yz3kTfkJ2KBPud4CpjoHVAptOm9Zmw==",
       "dev": true
     },
     "@types/long": {
@@ -1958,25 +2053,10 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
       "dev": true
     },
-    "@types/md5-file": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/md5-file/-/md5-file-4.0.2.tgz",
-      "integrity": "sha512-8gacRfEqLrmZ6KofpFfxyjsm/LYepeWUWUJGaf5A9W9J5B2/dRZMdkDqFDL6YDa9IweH12IO76jO7mpsK2B3wg==",
-      "dev": true
-    },
-    "@types/mkdirp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
-      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
-      "version": "14.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
-      "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==",
+      "version": "14.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.0.tgz",
+      "integrity": "sha512-SOIyrdADB4cq6eY1F+9iU48iIomFAPltu11LCvA9PKcyEwHadjCFzNVPotAR+oEJA0bCP4Xvvgy+vwu1ZjVh8g==",
       "dev": true
     },
     "@types/pbkdf2": {
@@ -1997,22 +2077,10 @@
         "@types/node": "*"
       }
     },
-    "@types/semver": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.3.tgz",
-      "integrity": "sha512-jQxClWFzv9IXdLdhSaTf16XI3NYe6zrEbckSpb5xhKfPbWgIyAY0AFyWWWfaiDcBuj3UHmMkCIwSRqpKMTZL2Q==",
-      "dev": true
-    },
     "@types/tmp": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
       "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
     "@types/yauzl": {
@@ -2246,9 +2314,9 @@
       }
     },
     "abstract-logging": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.0.tgz",
-      "integrity": "sha512-/oA9z7JszpIioo6J6dB79LVUgJ3eD3cxkAmdCkvWWS+Y9tPtALs1rLqOekLUXUbYqM2fB9TTK0ibAyZJJOP/CA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-1.0.0.tgz",
+      "integrity": "sha1-i33q/TEFWbwo93ck3RuzAXcnjBs=",
       "dev": true
     },
     "accepts": {
@@ -2268,9 +2336,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
     "aes-js": {
@@ -2715,6 +2783,30 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
+    "async.nexttick": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.nexttick/-/async.nexttick-0.5.2.tgz",
+      "integrity": "sha1-Wi6qemLO/dn1HfykgFibwkIY+Z4=",
+      "dev": true,
+      "requires": {
+        "async.util.nexttick": "0.5.2"
+      }
+    },
+    "async.util.nexttick": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.util.nexttick/-/async.util.nexttick-0.5.2.tgz",
+      "integrity": "sha1-UbmyNhHoC9iaGoGIcrv2h3ls35U=",
+      "dev": true,
+      "requires": {
+        "async.util.setimmediate": "0.5.2"
+      }
+    },
+    "async.util.setimmediate": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/async.util.setimmediate/-/async.util.setimmediate-0.5.2.tgz",
+      "integrity": "sha1-KBLrq/KlgCd1jUvHeT0cz68QJV8=",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2793,7 +2885,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -2919,13 +3012,13 @@
       }
     },
     "bcrypto": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.3.0.tgz",
-      "integrity": "sha512-SP48cpoc4BkEPNOErdsZ1VjbtdXY/C0f5wAywWniLne/Fd/5oOBqLbC6ZavngLvk4oik76g4I7PO5KduJoqECQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.1.0.tgz",
+      "integrity": "sha512-WEs5g7WHdEdLLcsvhE7Z1AXv0G+hb+bJhSUYM7samFNrH051XhcFVWxAbAZDmIU1HWjpjhmQ+HqBar7UC/qrzQ==",
       "dev": true,
       "requires": {
-        "bufio": "~1.0.7",
-        "loady": "~0.0.5"
+        "bufio": "~1.0.6",
+        "loady": "~0.0.1"
       }
     },
     "bech32": {
@@ -3073,12 +3166,12 @@
       "dev": true
     },
     "blob-to-it": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-0.0.2.tgz",
-      "integrity": "sha512-3/NRr0mUWQTkS71MYEC1teLbT5BTs7RZ6VMPXDV6qApjw3B4TAZspQuvDkYfHuD/XzL5p/RO91x5XRPeJvcCqg==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-0.0.1.tgz",
+      "integrity": "sha512-gvOVIs0YUpKHAwvhoJcRs81LJrOb+kwOol0/NnF/JgD0a5i9SJ/Es/njJo3NgFzb+x/FDPh4cD4D1KnrBeUWuw==",
       "dev": true,
       "requires": {
-        "browser-readablestream-to-it": "^0.0.2"
+        "browser-readablestream-to-it": "^0.0.1"
       }
     },
     "block-stream": {
@@ -3233,6 +3326,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3264,9 +3358,9 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-readablestream-to-it": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-0.0.2.tgz",
-      "integrity": "sha512-bbiTccngeAbPmpTUJcUyr6JhivADKV9xkNJVLdA91vjdzXyFBZ6fgrzElQsV3k1UNGQACRTl3p4y+cEGG9U48A==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-0.0.1.tgz",
+      "integrity": "sha512-leRiI4bLRr7K8znNmQZ3frgL8A7aX4LI4g7444YEtT3alaxqem+XPGsJmOlFRRdRqjFpvf2wW4dXKcgBLxypVg==",
       "dev": true
     },
     "browser-stdout": {
@@ -3356,15 +3450,15 @@
       }
     },
     "browserslist": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.1.tgz",
-      "integrity": "sha512-zyBTIHydW37pnb63c7fHFXUG6EcqWOqoMdDx6cdyaDFriZ20EoVxcE95S54N+heRqY8m8IUgB5zYta/gCwSaaA==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.2.tgz",
+      "integrity": "sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001124",
-        "electron-to-chromium": "^1.3.562",
+        "caniuse-lite": "^1.0.30001125",
+        "electron-to-chromium": "^1.3.564",
         "escalade": "^3.0.2",
-        "node-releases": "^1.1.60"
+        "node-releases": "^1.1.61"
       }
     },
     "bs58": {
@@ -3586,9 +3680,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001124",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-      "integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
+      "version": "1.0.30001125",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz",
+      "integrity": "sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==",
       "dev": true
     },
     "caseless": {
@@ -3698,17 +3792,16 @@
       "dev": true
     },
     "cid-tool": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-1.0.0.tgz",
-      "integrity": "sha512-K7NGZBo1P6N2ogUmBtJWwMNfqXxU3ROiCHs+YKDDwBecsZ46J+9vJ6pOEJzds1JzqRnYRxxZBPfgBEYQebMXJg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-0.4.1.tgz",
+      "integrity": "sha512-nASd+T8H9hY1Z3Z9ylvWlUUCFZ1msFaGAx7Y9+peqJEbrnSLErJXT8YJFRyUtkkP8+0NYE9g8JRUhC5+pj8SJw==",
       "dev": true,
       "requires": {
-        "cids": "^1.0.0",
+        "cids": "~0.8.0",
         "explain-error": "^1.0.4",
-        "multibase": "^3.0.0",
-        "multihashes": "^3.0.1",
+        "multibase": "~0.7.0",
+        "multihashes": "~0.4.14",
         "split2": "^3.1.1",
-        "uint8arrays": "^1.1.0",
         "yargs": "^15.0.2"
       },
       "dependencies": {
@@ -3726,6 +3819,42 @@
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
+          }
+        },
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "multihashes": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.6.0",
+                "multibase": "^1.0.1",
+                "varint": "^5.0.0"
+              }
+            }
           }
         },
         "cliui": {
@@ -3783,6 +3912,27 @@
           "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
           }
         },
         "p-locate": {
@@ -3863,15 +4013,47 @@
       }
     },
     "cids": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-1.0.0.tgz",
-      "integrity": "sha512-HEBCIElSiXlkgZq3dgHJc3eDcnFteFp96N8/1/oqX5lkxBtB66sZ12jqEP3g7Ut++jEk6kIUGifQ1Qrya1jcNQ==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
       "requires": {
+        "buffer": "^5.5.0",
         "class-is": "^1.1.0",
-        "multibase": "^3.0.0",
-        "multicodec": "^2.0.0",
-        "multihashes": "^3.0.1",
-        "uint8arrays": "^1.0.0"
+        "multibase": "~0.6.0",
+        "multicodec": "^1.0.0",
+        "multihashes": "~0.4.15"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        }
       }
     },
     "cipher-base": {
@@ -4070,7 +4252,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -4369,13 +4552,49 @@
       "dev": true
     },
     "dag-cbor-links": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-2.0.0.tgz",
-      "integrity": "sha512-ra3oaFkrl57zcZf0l5F/L9l8QTdqdO9XZLpbXsNT0EX4NPL34RDN4r6Uuk6LI1WQLFfM0prSCbAEdOWxzUJo3A==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-1.3.6.tgz",
+      "integrity": "sha512-UeslQGj1cF5FLDLUlutDdeWKOnN3QVrqzIFOwOq4kQud+2aOxQjmlFnsU/uNdkJaz6H66RvbPGivueQB0fL5Iw==",
       "dev": true,
       "requires": {
-        "cids": "^1.0.0",
-        "ipld-dag-cbor": "^0.17.0"
+        "cids": "^0.8.0",
+        "ipld-dag-cbor": "^0.16.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        }
       }
     },
     "dashdash": {
@@ -4389,49 +4608,26 @@
       }
     },
     "datastore-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-2.0.0.tgz",
-      "integrity": "sha512-E6SS3GEZNMCRZScWO98qQ14MIb7+3MLsJtcgla/ULCjfnhThsUE21HN+wT0+QLoYrKR54puWy/3XKp5N+5+zyA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-1.1.0.tgz",
+      "integrity": "sha512-tn42Qy6t1V5otG4R3hq7yW4vpNaKc8/GXEYnLv8oeGNSQfEWPnfz1x5Sto080N7IsluzOUWK/W+a4m4Er8DnAA==",
       "dev": true,
       "requires": {
+        "buffer": "^5.5.0",
         "debug": "^4.1.1",
-        "interface-datastore": "^2.0.0",
-        "ipfs-utils": "^2.3.1"
-      },
-      "dependencies": {
-        "ipfs-utils": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "any-signal": "^1.1.0",
-            "buffer": "^5.6.0",
-            "err-code": "^2.0.0",
-            "fs-extra": "^9.0.1",
-            "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.8",
-            "it-to-stream": "^0.1.2",
-            "merge-options": "^2.0.0",
-            "nanoid": "^3.1.3",
-            "node-fetch": "^2.6.0",
-            "stream-to-it": "^0.2.0"
-          }
-        }
+        "interface-datastore": "^1.0.2"
       }
     },
     "datastore-fs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-2.0.1.tgz",
-      "integrity": "sha512-W0qOEJDHVmzSfCXMBcgnHI7n0SROQ7vpD24v9AicVWE/DPju4CUWl/1NHSQO3RR3ooaFdG31c1J2OjDKJO6+Fg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-1.1.0.tgz",
+      "integrity": "sha512-z/lsSMxi7omrPwCgGjZ1OrPN0cq35sFMWhTHnnF1ekvD3fxntB1gNqEi9ioMMJNX8OQap7JvYT40LdtZZx7mTg==",
       "dev": true,
       "requires": {
-        "datastore-core": "^2.0.0",
+        "datastore-core": "^1.1.0",
         "fast-write-atomic": "^0.2.0",
-        "interface-datastore": "^2.0.0",
-        "it-glob": "0.0.8",
+        "glob": "^7.1.3",
+        "interface-datastore": "^1.0.2",
         "mkdirp": "^1.0.4"
       },
       "dependencies": {
@@ -4444,26 +4640,39 @@
       }
     },
     "datastore-level": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-2.0.0.tgz",
-      "integrity": "sha512-52qSxZG75QRqO502cSvnYnXj/5sO29Dvtd9uuiRLSzUaSPher8pS0hl5xzlx7zglpzAjQpjaq9oy2UFO6vMn6g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-1.1.0.tgz",
+      "integrity": "sha512-XEuXC3mq2BTUdhOvx7vwD93GN1O8SJf1HL/EOlmVcxLt3EHtDpX5pqZmiDdrXIAfe4uiEuSfFu2tKycuz1PMZA==",
       "dev": true,
       "requires": {
-        "datastore-core": "^2.0.0",
-        "interface-datastore": "^2.0.0",
+        "datastore-core": "^1.1.0",
+        "interface-datastore": "^1.0.2",
         "level": "^5.0.1"
       }
     },
     "datastore-pubsub": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.4.1.tgz",
-      "integrity": "sha512-OVKIlSqILBSFApJ5FPmiWaSA71l53sX52sV0JgyGBaghzqbFTTB1HQikB8npSyGMEJfmpCVhKue9rkTHF+WoXg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.3.3.tgz",
+      "integrity": "sha512-QMGKZpOnwMO4UK14aU1GfsiyXv77F//7jj8mjTmbdma+iVBSLW1aNq6koZtw46DM7K9LfhlfLHyvyAl4JJp7fA==",
       "dev": true,
       "requires": {
+        "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.3",
-        "interface-datastore": "^2.0.0",
-        "uint8arrays": "^1.1.0"
+        "interface-datastore": "^1.0.4",
+        "multibase": "^0.7.0"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        }
       }
     },
     "dateformat": {
@@ -4776,9 +4985,9 @@
       "dev": true
     },
     "dot-prop": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-      "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
@@ -4877,9 +5086,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.562",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.562.tgz",
-      "integrity": "sha512-WhRe6liQ2q/w1MZc8mD8INkenHivuHdrr4r5EQHNomy3NJux+incP6M6lDMd0paShP3MD0WGe5R1TWmEClf+Bg==",
+      "version": "1.3.564",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.564.tgz",
+      "integrity": "sha512-fNaYN3EtKQWLQsrKXui8mzcryJXuA0LbCLoizeX6oayG2emBaS5MauKjCPAvc29NEY4FpLHIUWiP+Y0Bfrs5dg==",
       "dev": true
     },
     "elliptic": {
@@ -6054,9 +6263,9 @@
       }
     },
     "ethers": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.10.tgz",
-      "integrity": "sha512-w5VgwFsEJpsuXzJh+jTpEi48D0IlgtDLE7w753SRH7PqbITZvu2R63cbp9GQIh+lw7GqpcDo/BvRQiJhpQz3kw==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.12.tgz",
+      "integrity": "sha512-mgF1ZLd1y5r+hS1IPATKwKx5k/PCSqz4PEQjMR+er+Hhu6IefVVcoYATUMjmK4FG+3PAkorRMA9rJ4Y/fdW0UA==",
       "requires": {
         "@ethersproject/abi": "^5.0.3",
         "@ethersproject/abstract-provider": "^5.0.3",
@@ -6424,9 +6633,9 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filesize": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
-      "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
       "dev": true
     },
     "fill-range": {
@@ -7797,15 +8006,15 @@
       }
     },
     "hapi-pino": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-8.3.0.tgz",
-      "integrity": "sha512-8Cm1WIs6jp8B9ZzYqPFbCWNKt6F6jNCfLmCIHmPsm35sTOvT/r5+d9KpYR2vigWQRLS23VBXzOqUVESpP7r+jA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-6.5.0.tgz",
+      "integrity": "sha512-262F+AJpNHCCGIPpqugPtVWU2plXyCcjeXkbcrD60LRg/tcobLAHuzR6usNcKCansJbrcCy+/kBXYcKQGae7+g==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "abstract-logging": "^2.0.0",
-        "pino": "^6.0.0",
-        "pino-pretty": "^4.0.0"
+        "@hapi/hoek": "^8.3.0",
+        "abstract-logging": "^1.0.0",
+        "pino": "^5.13.5",
+        "pino-pretty": "^3.2.2"
       }
     },
     "har-schema": {
@@ -8336,14 +8545,15 @@
       }
     },
     "interface-datastore": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-2.0.0.tgz",
-      "integrity": "sha512-wOImix5uVEZWo+8zPSRMJ9nHbszZi3PhZ14KHLN7oRQjaYQtjtOpYj6n5EXTjDAfIQI8KN9vntHXxyAw1lcRIA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
+      "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
       "dev": true,
       "requires": {
+        "buffer": "^5.5.0",
         "class-is": "^1.1.0",
         "err-code": "^2.0.1",
-        "ipfs-utils": "^2.3.1",
+        "ipfs-utils": "^2.2.2",
         "iso-random-stream": "^1.1.1",
         "it-all": "^1.0.2",
         "it-drain": "^1.0.1",
@@ -8424,28 +8634,30 @@
       "dev": true
     },
     "ipfs": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.50.1.tgz",
-      "integrity": "sha512-TTQzDoElF1ahcwebXXho2q+0vVsUz8rDKnTnz44QOkSB2cgYIIT32VIXxgFgoy+CayoFa+pybexQqR2lKRtajw==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.49.1.tgz",
+      "integrity": "sha512-pVTs9/IXrW/nQ4loj8uOsEOLcRvdgp9vRotw0g+ZGEUVMKgRLTvSacvY6ZBALThn6LtrZRJcFRXkpdvLCB6Utg==",
       "dev": true,
       "requires": {
-        "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "^9.1.0",
-        "@hapi/content": "^5.0.2",
-        "@hapi/hapi": "^20.0.0",
+        "@hapi/ammo": "^3.1.2",
+        "@hapi/boom": "^7.4.3",
+        "@hapi/content": "^4.1.0",
+        "@hapi/hapi": "^18.4.0",
+        "@hapi/joi": "^15.1.0",
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
         "array-shuffle": "^1.0.1",
         "bignumber.js": "^9.0.0",
         "bl": "^4.0.2",
+        "bs58": "^4.0.1",
+        "buffer": "^5.6.0",
         "byteman": "^1.3.5",
-        "cbor": "^5.0.1",
-        "cid-tool": "^1.0.0",
-        "cids": "^1.0.0",
+        "cid-tool": "^0.4.0",
+        "cids": "^0.8.3",
         "class-is": "^1.1.0",
-        "dag-cbor-links": "^2.0.0",
-        "datastore-core": "^2.0.0",
-        "datastore-pubsub": "^0.4.0",
+        "dag-cbor-links": "^1.3.3",
+        "datastore-core": "^1.1.0",
+        "datastore-pubsub": "^0.3.2",
         "debug": "^4.1.0",
         "dlv": "^1.1.3",
         "err-code": "^2.0.0",
@@ -8454,88 +8666,86 @@
         "fnv1a": "^1.0.1",
         "get-folder-size": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "hapi-pino": "^8.2.0",
+        "hapi-pino": "^6.1.0",
         "hashlru": "^2.3.0",
-        "interface-datastore": "^2.0.0",
-        "ipfs-bitswap": "^3.0.0",
-        "ipfs-block-service": "^0.18.0",
-        "ipfs-core-utils": "^0.4.0",
-        "ipfs-http-client": "^46.1.1",
-        "ipfs-http-response": "^0.6.0",
-        "ipfs-repo": "^6.0.3",
-        "ipfs-unixfs": "^2.0.2",
-        "ipfs-unixfs-exporter": "^3.0.2",
-        "ipfs-unixfs-importer": "^3.0.2",
+        "interface-datastore": "^1.0.2",
+        "ipfs-bitswap": "^2.0.1",
+        "ipfs-block-service": "^0.17.1",
+        "ipfs-core-utils": "^0.3.2",
+        "ipfs-http-client": "^46.0.1",
+        "ipfs-http-response": "^0.5.0",
+        "ipfs-repo": "^4.0.0",
+        "ipfs-unixfs": "^1.0.3",
+        "ipfs-unixfs-exporter": "^2.0.2",
+        "ipfs-unixfs-importer": "^2.0.2",
         "ipfs-utils": "^3.0.0",
-        "ipld": "^0.27.1",
-        "ipld-bitcoin": "^0.4.0",
-        "ipld-block": "^0.10.0",
-        "ipld-dag-cbor": "^0.17.0",
-        "ipld-dag-pb": "^0.20.0",
-        "ipld-ethereum": "^5.0.1",
-        "ipld-git": "^0.6.1",
-        "ipld-raw": "^6.0.0",
-        "ipld-zcash": "^0.5.0",
-        "ipns": "^0.8.0",
+        "ipld": "^0.26.2",
+        "ipld-bitcoin": "^0.3.0",
+        "ipld-block": "^0.9.2",
+        "ipld-dag-cbor": "^0.16.0",
+        "ipld-dag-pb": "^0.19.0",
+        "ipld-ethereum": "^4.0.0",
+        "ipld-git": "^0.5.0",
+        "ipld-raw": "^5.0.0",
+        "ipld-zcash": "^0.4.0",
+        "ipns": "^0.7.1",
         "is-domain-name": "^1.0.1",
-        "is-ipfs": "^2.0.0",
+        "is-ipfs": "^1.0.3",
         "iso-url": "^0.4.7",
         "it-all": "^1.0.1",
         "it-concat": "^1.0.0",
         "it-drain": "^1.0.1",
         "it-first": "^1.0.1",
         "it-glob": "0.0.8",
-        "it-last": "^1.0.2",
-        "it-map": "^1.0.2",
+        "it-last": "^1.0.1",
+        "it-map": "^1.0.0",
         "it-multipart": "^1.0.1",
         "it-pipe": "^1.1.0",
         "it-tar": "^1.2.2",
         "it-to-stream": "^0.1.1",
         "iterable-ndjson": "^1.1.0",
-        "joi": "^17.2.1",
         "jsondiffpatch": "^0.4.1",
         "just-safe-set": "^2.1.0",
-        "libp2p": "^0.29.0",
-        "libp2p-bootstrap": "^0.12.0",
-        "libp2p-crypto": "^0.18.0",
-        "libp2p-delegated-content-routing": "^0.7.0",
-        "libp2p-delegated-peer-routing": "^0.7.0",
-        "libp2p-floodsub": "^0.23.0",
-        "libp2p-gossipsub": "^0.6.0",
-        "libp2p-kad-dht": "^0.20.0",
-        "libp2p-mdns": "^0.15.0",
-        "libp2p-mplex": "^0.10.0",
-        "libp2p-noise": "^2.0.0",
-        "libp2p-record": "^0.9.0",
-        "libp2p-secio": "^0.13.0",
-        "libp2p-tcp": "^0.15.0",
-        "libp2p-webrtc-star": "^0.20.0",
-        "libp2p-websockets": "^0.14.0",
-        "mafmt": "^8.0.0",
+        "libp2p": "^0.28.10",
+        "libp2p-bootstrap": "^0.11.0",
+        "libp2p-crypto": "^0.17.9",
+        "libp2p-delegated-content-routing": "^0.5.0",
+        "libp2p-delegated-peer-routing": "^0.5.0",
+        "libp2p-floodsub": "^0.21.0",
+        "libp2p-gossipsub": "^0.4.0",
+        "libp2p-kad-dht": "^0.19.9",
+        "libp2p-mdns": "^0.14.1",
+        "libp2p-mplex": "^0.9.5",
+        "libp2p-noise": "^1.1.1",
+        "libp2p-record": "^0.7.3",
+        "libp2p-secio": "^0.12.6",
+        "libp2p-tcp": "^0.14.5",
+        "libp2p-webrtc-star": "^0.18.0",
+        "libp2p-websockets": "^0.13.3",
+        "mafmt": "^7.0.0",
         "merge-options": "^2.0.0",
         "mortice": "^2.0.0",
-        "multiaddr": "^8.0.0",
-        "multiaddr-to-uri": "^6.0.0",
-        "multibase": "^3.0.0",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.1",
+        "multiaddr": "^7.4.3",
+        "multiaddr-to-uri": "^5.1.0",
+        "multibase": "^1.0.1",
+        "multicodec": "^1.0.0",
+        "multihashing-async": "^1.0.0",
         "p-defer": "^3.0.0",
         "p-queue": "^6.1.0",
         "parse-duration": "^0.4.4",
-        "peer-id": "^0.14.0",
+        "peer-id": "^0.13.12",
         "pretty-bytes": "^5.3.0",
         "progress": "^2.0.1",
         "prom-client": "^12.0.0",
         "prometheus-gc-stats": "^0.6.0",
-        "protons": "^2.0.0",
+        "protons": "^1.2.1",
         "semver": "^7.3.2",
         "stream-to-it": "^0.2.1",
         "streaming-iterables": "^5.0.0",
         "temp": "^0.9.0",
         "timeout-abort-controller": "^1.1.0",
-        "uint8arrays": "^1.1.0",
         "update-notifier": "^4.0.0",
-        "uri-to-multiaddr": "^4.0.0",
+        "uri-to-multiaddr": "^3.0.2",
         "varint": "^5.0.0",
         "yargs": "^15.1.0",
         "yargs-promise": "^1.1.0"
@@ -8555,6 +8765,19 @@
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
+          }
+        },
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
           }
         },
         "cliui": {
@@ -8599,6 +8822,73 @@
             "path-exists": "^4.0.0"
           }
         },
+        "ipfs-repo": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-4.0.0.tgz",
+          "integrity": "sha512-rhmRjO3ekS4/RzgNB1EQOudKCCYK23Lb2/E6eD3So5r0bX1PvDdybbzfpDj05HBoNmvDy9pYDJzdtdH7a4gP3w==",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "^9.0.0",
+            "buffer": "^5.6.0",
+            "bytes": "^3.1.0",
+            "cids": "^0.8.0",
+            "datastore-core": "^1.1.0",
+            "datastore-fs": "^1.1.0",
+            "datastore-level": "^1.1.0",
+            "debug": "^4.1.0",
+            "err-code": "^2.0.0",
+            "interface-datastore": "^1.0.2",
+            "ipfs-repo-migrations": "^1.0.0",
+            "ipfs-utils": "^2.2.0",
+            "ipld-block": "^0.9.1",
+            "it-map": "^1.0.2",
+            "it-pushable": "^1.4.0",
+            "just-safe-get": "^2.0.0",
+            "just-safe-set": "^2.1.0",
+            "multibase": "^1.0.1",
+            "p-queue": "^6.0.0",
+            "proper-lockfile": "^4.0.0",
+            "sort-keys": "^4.0.0"
+          },
+          "dependencies": {
+            "ipfs-utils": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+              "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+              "dev": true,
+              "requires": {
+                "abort-controller": "^3.0.0",
+                "any-signal": "^1.1.0",
+                "buffer": "^5.6.0",
+                "err-code": "^2.0.0",
+                "fs-extra": "^9.0.1",
+                "is-electron": "^2.2.0",
+                "iso-url": "^0.4.7",
+                "it-glob": "0.0.8",
+                "it-to-stream": "^0.1.2",
+                "merge-options": "^2.0.0",
+                "nanoid": "^3.1.3",
+                "node-fetch": "^2.6.0",
+                "stream-to-it": "^0.2.0"
+              }
+            }
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
+          "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "cids": "~0.8.3",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.3",
+            "multihashing-async": "^1.0.0",
+            "protons": "^1.2.1",
+            "stable": "^0.1.8"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -8606,24 +8896,41 @@
           "dev": true
         },
         "libp2p-crypto": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
-          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
           "dev": true,
           "requires": {
+            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^2.0.0",
+            "protons": "^1.2.1",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.1.0",
+            "uint8arrays": "^1.0.0",
             "ursa-optional": "^0.10.1"
+          },
+          "dependencies": {
+            "multihashing-async": {
+              "version": "0.8.2",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+              "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+              "dev": true,
+              "requires": {
+                "blakejs": "^1.1.0",
+                "buffer": "^5.4.3",
+                "err-code": "^2.0.0",
+                "js-sha3": "^0.8.0",
+                "multihashes": "^1.0.1",
+                "murmurhash3js-revisited": "^3.0.0"
+              }
+            }
           }
         },
         "locate-path": {
@@ -8633,6 +8940,41 @@
           "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         },
         "node-gyp-build": {
@@ -8655,18 +8997,6 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
-        },
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
-          "dev": true,
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
-            "varint": "^5.0.0"
-          }
         },
         "secp256k1": {
           "version": "4.0.2",
@@ -8748,135 +9078,346 @@
       }
     },
     "ipfs-bitswap": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-3.0.0.tgz",
-      "integrity": "sha512-9rX9vMUEegk61O4OoUWBUcU/WLLwALhyzHQdJzqW1DCn+nNnZVbRrzIWY1v5PnlywMtcUvd/ennpegVKCPuiUA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-2.0.1.tgz",
+      "integrity": "sha512-kZauF0XwatrMe0SfdKs4abrarcVNRzdfWFaz+kodGl1Uq7aryf/DZmSutw3NFkJDVnYWAQ7l55VsDRxC4kD6dg==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
         "bignumber.js": "^9.0.0",
-        "cids": "^1.0.0",
+        "cids": "^0.8.3",
         "debug": "^4.1.0",
-        "ipld-block": "^0.10.0",
+        "ipld-block": "^0.9.1",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.1.0",
         "just-debounce-it": "^1.1.0",
-        "libp2p-interfaces": "^0.4.1",
+        "libp2p-interfaces": "^0.3.0",
         "moving-average": "^1.0.0",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.1",
-        "protons": "^2.0.0",
+        "multicodec": "^1.0.3",
+        "multihashing-async": "^1.0.0",
+        "protons": "^1.0.1",
         "streaming-iterables": "^5.0.2",
-        "uint8arrays": "^1.1.0",
-        "varint-decoder": "^1.0.0"
+        "varint-decoder": "^0.4.0"
       },
       "dependencies": {
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
             "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
     },
     "ipfs-block-service": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.18.0.tgz",
-      "integrity": "sha512-tye5Uxbf3bYlfcGkV3CspP2JNcM2Ggm/5Kxph0jGKtAZtgfFxUq3NeSmvS6nGtZZBaFP4nwRF2yq7dQMALWzVg==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.17.1.tgz",
+      "integrity": "sha512-I12f6nXCJfkv9IoxZTRbHcIAa/bptSGAMDawAm2GUqD8lNPs3w2KuLpxBX6doZomhJ07C5VtaiW0pmWY5L52WA==",
       "dev": true,
       "requires": {
         "err-code": "^2.0.0",
-        "streaming-iterables": "^5.0.2"
+        "streaming-iterables": "^4.1.0"
+      },
+      "dependencies": {
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+          "dev": true
+        }
       }
     },
     "ipfs-core-utils": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.4.0.tgz",
-      "integrity": "sha512-IBPFvYjWPfVFpCeYUL/0gCUOabdBhh7aO5i4tU//UlF2gVCXPH4PRYlbBH9WM83zE2+o4vDi+dBXsdAI6nLPAg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.3.2.tgz",
+      "integrity": "sha512-4kn6qbhYsyn48HeH7qAKPG07CxwEr1EsgRccGQOUy/5OjcfqIjw4HnBwYmsRU6QuWsNR7nOAhwrVc6Y3glVvnQ==",
       "dev": true,
       "requires": {
-        "blob-to-it": "0.0.2",
-        "browser-readablestream-to-it": "0.0.2",
-        "cids": "^1.0.0",
+        "blob-to-it": "0.0.1",
+        "browser-readablestream-to-it": "0.0.1",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
         "err-code": "^2.0.0",
         "ipfs-utils": "^3.0.0",
         "it-all": "^1.0.1",
-        "it-map": "^1.0.2",
-        "it-peekable": "0.0.1",
-        "uint8arrays": "^1.1.0"
+        "it-map": "^1.0.0",
+        "it-peekable": "0.0.1"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        }
       }
     },
     "ipfs-http-client": {
-      "version": "46.1.1",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-46.1.1.tgz",
-      "integrity": "sha512-8E2tKdLke9Sd/7burgfokhIcOnQoWAjWrYR/i2CYC0pBTkxHeKcEGUG3oQ1cMPfyWVsRqDG4QskYRYppjsBjHg==",
+      "version": "46.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-46.0.1.tgz",
+      "integrity": "sha512-/AK3lpeoxzyagmuAix1BNmDH/R5PpB+VdFtjV6mC57XE6/OoYl5FCmgxOtz/gusfnTLLjm87i9I5+4IbuzVhFg==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
         "bignumber.js": "^9.0.0",
-        "cids": "^1.0.0",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
         "debug": "^4.1.0",
         "form-data": "^3.0.0",
-        "ipfs-core-utils": "^0.4.0",
+        "ipfs-core-utils": "^0.3.2",
         "ipfs-utils": "^3.0.0",
-        "ipld-block": "^0.10.0",
-        "ipld-dag-cbor": "^0.17.0",
-        "ipld-dag-pb": "^0.20.0",
-        "ipld-raw": "^6.0.0",
+        "ipld-block": "^0.9.2",
+        "ipld-dag-cbor": "^0.16.0",
+        "ipld-dag-pb": "^0.19.0",
+        "ipld-raw": "^5.0.0",
         "iso-url": "^0.4.7",
-        "it-last": "^1.0.2",
-        "it-map": "^1.0.2",
+        "it-last": "^1.0.1",
         "it-tar": "^1.2.2",
         "it-to-buffer": "^1.0.0",
         "it-to-stream": "^0.1.1",
         "merge-options": "^2.0.0",
-        "multiaddr": "^8.0.0",
-        "multiaddr-to-uri": "^6.0.0",
-        "multibase": "^3.0.0",
-        "multicodec": "^2.0.0",
-        "multihashes": "^3.0.1",
+        "multiaddr": "^7.4.3",
+        "multiaddr-to-uri": "^5.1.0",
+        "multibase": "^1.0.1",
+        "multicodec": "^1.0.0",
+        "multihashes": "^1.0.1",
         "nanoid": "^3.0.2",
         "node-fetch": "^2.6.0",
         "parse-duration": "^0.4.4",
-        "stream-to-it": "^0.2.1",
-        "uint8arrays": "^1.1.0"
+        "stream-to-it": "^0.2.1"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
+          "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "cids": "~0.8.3",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.3",
+            "multihashing-async": "^1.0.0",
+            "protons": "^1.2.1",
+            "stable": "^0.1.8"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipfs-http-response": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.6.0.tgz",
-      "integrity": "sha512-x1x4ZGvR0azgasT2ql6qKjiH+aPVjra9rJbNq89KzQVxrQLf9zlEHfLzfL7p8m0iYY4MiD+fW+QZF8xA18Xh2g==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.5.1.tgz",
+      "integrity": "sha512-Mu7LWkCCE2C8H0he2jJKY7KtmmjuSaft+wSzAZedT1WRvsgv/05JI4XXlGc2Z37eB9q0nQPFKIE83I7gJRNEaw==",
       "dev": true,
       "requires": {
+        "cids": "~0.8.1",
         "debug": "^4.1.1",
-        "file-type": "^14.7.1",
-        "filesize": "^6.1.0",
+        "file-type": "^8.0.0",
+        "filesize": "^3.6.1",
         "it-buffer": "^0.1.1",
         "it-concat": "^1.0.0",
         "it-reader": "^2.1.0",
         "it-to-stream": "^0.1.1",
         "mime-types": "^2.1.27",
-        "multihashes": "^3.0.1",
+        "multihashes": "~0.4.19",
         "p-try-each": "^1.0.1"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          },
+          "dependencies": {
+            "multihashes": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.6.0",
+                "multibase": "^1.0.1",
+                "varint": "^5.0.0"
+              }
+            }
+          }
+        },
+        "file-type": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
+          "dev": true
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        }
       }
     },
     "ipfs-log": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/ipfs-log/-/ipfs-log-4.6.4.tgz",
-      "integrity": "sha512-dleG9/rIH2yKVvSbhEzSERHwpsE12V8BiMzc4mXhjMGbaf6mn1T1cu+dEKCmC2Om/7v//5gthGsI/vukgwIh0g==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/ipfs-log/-/ipfs-log-4.6.5.tgz",
+      "integrity": "sha512-FJN5yd1LCbVvG3+fVkqfB42TOMtvbTqSYvkd4LWj4tFtF16uh2T76LkRJud6CXJChPynRqS6zsjAvLNAZKwp6g==",
       "requires": {
         "json-stringify-deterministic": "^1.0.1",
         "multihashing-async": "^2.0.1",
         "orbit-db-identity-provider": "~0.3.1",
-        "orbit-db-io": "~0.3.0",
+        "orbit-db-io": "~0.2.0",
         "p-do-whilst": "^1.1.0",
         "p-each-series": "^2.1.0",
         "p-map": "^4.0.0",
@@ -8912,6 +9453,92 @@
         "uint8arrays": "^1.0.0"
       },
       "dependencies": {
+        "cids": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-1.0.0.tgz",
+          "integrity": "sha512-HEBCIElSiXlkgZq3dgHJc3eDcnFteFp96N8/1/oqX5lkxBtB66sZ12jqEP3g7Ut++jEk6kIUGifQ1Qrya1jcNQ==",
+          "dev": true,
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashes": "^3.0.1",
+            "uint8arrays": "^1.0.0"
+          }
+        },
+        "datastore-core": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-2.0.0.tgz",
+          "integrity": "sha512-E6SS3GEZNMCRZScWO98qQ14MIb7+3MLsJtcgla/ULCjfnhThsUE21HN+wT0+QLoYrKR54puWy/3XKp5N+5+zyA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "interface-datastore": "^2.0.0",
+            "ipfs-utils": "^2.3.1"
+          }
+        },
+        "datastore-fs": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-2.0.1.tgz",
+          "integrity": "sha512-W0qOEJDHVmzSfCXMBcgnHI7n0SROQ7vpD24v9AicVWE/DPju4CUWl/1NHSQO3RR3ooaFdG31c1J2OjDKJO6+Fg==",
+          "dev": true,
+          "requires": {
+            "datastore-core": "^2.0.0",
+            "fast-write-atomic": "^0.2.0",
+            "interface-datastore": "^2.0.0",
+            "it-glob": "0.0.8",
+            "mkdirp": "^1.0.4"
+          }
+        },
+        "datastore-level": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-2.0.0.tgz",
+          "integrity": "sha512-52qSxZG75QRqO502cSvnYnXj/5sO29Dvtd9uuiRLSzUaSPher8pS0hl5xzlx7zglpzAjQpjaq9oy2UFO6vMn6g==",
+          "dev": true,
+          "requires": {
+            "datastore-core": "^2.0.0",
+            "interface-datastore": "^2.0.0",
+            "level": "^5.0.1"
+          }
+        },
+        "interface-datastore": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-2.0.0.tgz",
+          "integrity": "sha512-wOImix5uVEZWo+8zPSRMJ9nHbszZi3PhZ14KHLN7oRQjaYQtjtOpYj6n5EXTjDAfIQI8KN9vntHXxyAw1lcRIA==",
+          "dev": true,
+          "requires": {
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.1",
+            "ipfs-utils": "^2.3.1",
+            "iso-random-stream": "^1.1.1",
+            "it-all": "^1.0.2",
+            "it-drain": "^1.0.1",
+            "nanoid": "^3.0.2"
+          }
+        },
+        "ipfs-repo-migrations": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-5.0.5.tgz",
+          "integrity": "sha512-dbg9LY+f1MhKLCUTQ28z+TmS7+fC6dgZPJhsWpNXSSwicEgMjUssGMoaft9AjoOuOTISeF3WWVVKRqFpOvCxQg==",
+          "dev": true,
+          "requires": {
+            "cbor": "^5.0.2",
+            "cids": "^1.0.0",
+            "datastore-core": "^2.0.0",
+            "debug": "^4.1.0",
+            "fnv1a": "^1.0.1",
+            "interface-datastore": "^2.0.0",
+            "ipld-dag-pb": "^0.20.0",
+            "it-length": "0.0.2",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.0",
+            "proper-lockfile": "^4.1.1",
+            "protons": "^2.0.0",
+            "uint8arrays": "^1.0.0",
+            "varint": "^5.0.0"
+          }
+        },
         "ipfs-utils": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
@@ -8932,32 +9559,62 @@
             "node-fetch": "^2.6.0",
             "stream-to-it": "^0.2.0"
           }
-        }
-      }
-    },
-    "ipfs-repo-migrations": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-5.0.5.tgz",
-      "integrity": "sha512-dbg9LY+f1MhKLCUTQ28z+TmS7+fC6dgZPJhsWpNXSSwicEgMjUssGMoaft9AjoOuOTISeF3WWVVKRqFpOvCxQg==",
-      "dev": true,
-      "requires": {
-        "cbor": "^5.0.2",
-        "cids": "^1.0.0",
-        "datastore-core": "^2.0.0",
-        "debug": "^4.1.0",
-        "fnv1a": "^1.0.1",
-        "interface-datastore": "^2.0.0",
-        "ipld-dag-pb": "^0.20.0",
-        "it-length": "0.0.2",
-        "multibase": "^3.0.0",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.0",
-        "proper-lockfile": "^4.1.1",
-        "protons": "^2.0.0",
-        "uint8arrays": "^1.0.0",
-        "varint": "^5.0.0"
-      },
-      "dependencies": {
+        },
+        "ipld-block": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.10.1.tgz",
+          "integrity": "sha512-lPMfW9tA2hVZw9hdO/YSppTxFmA0+5zxcefBOlCTOn+12RLyy+pdepKMbQw8u0KESFu3pYVmabNRWuFGcgHLLw==",
+          "dev": true,
+          "requires": {
+            "cids": "^1.0.0",
+            "class-is": "^1.1.0"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.20.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.20.0.tgz",
+          "integrity": "sha512-zfM0EdaolqNjAxIrtpuGKvXxWk5YtH9jKinBuQGTcngOsWFQhyybGCTJHGNGGtRjHNJi2hz5Udy/8pzv4kcKyg==",
+          "dev": true,
+          "requires": {
+            "cids": "^1.0.0",
+            "class-is": "^1.1.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.0",
+            "protons": "^2.0.0",
+            "reset": "^0.1.0",
+            "run": "^1.4.0",
+            "stable": "^0.1.8",
+            "uint8arrays": "^1.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "multicodec": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.1.tgz",
+          "integrity": "sha512-YDYeWn9iGa76hOHAyyZa0kbt3tr5FLg1ZXUHrZUJltjnxxdbTIbHnxWLd2zTcMOjdT3QyO+Xs4bQgJUcC2RWUA==",
+          "dev": true,
+          "requires": {
+            "uint8arrays": "1.0.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+              "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+              "dev": true,
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.2"
+              }
+            }
+          }
+        },
         "protons": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
@@ -8967,70 +9624,195 @@
             "protocol-buffers-schema": "^3.3.1",
             "signed-varint": "^2.0.1",
             "uint8arrays": "^1.0.0",
+            "varint": "^5.0.0"
+          }
+        }
+      }
+    },
+    "ipfs-repo-migrations": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-1.0.1.tgz",
+      "integrity": "sha512-yPVm9hyhZxc3ZB7+5YJ1W1MOzXN+9Oyp/4xdmNyjsI9lTtf5s0PP2NqXcpxgDP09epNlMMt3LJEt4QP3qHrL/A==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
+        "datastore-core": "^1.1.0",
+        "datastore-fs": "^1.0.0",
+        "datastore-level": "^1.1.0",
+        "debug": "^4.1.0",
+        "interface-datastore": "^1.0.2",
+        "multibase": "^1.0.1",
+        "proper-lockfile": "^4.1.1"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
             "varint": "^5.0.0"
           }
         }
       }
     },
     "ipfs-unixfs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-2.0.3.tgz",
-      "integrity": "sha512-WpzG/VTqWBPh1cYW3CXk2naElYO3xU0rJnL3SBHbviZ6ZeHRadxR5k0v3/yxPuygs2AwBhaLqBNlV6uB6OCiQw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.3.tgz",
+      "integrity": "sha512-fCwC0vIuQrPSNDWzVKwf31T1tA3vLwlPTC5UgAD8ZrrDgOdeJlhyeqEsMX0fxtuxR3SAKscZr43Lgjrbd5qh0Q==",
       "dev": true,
       "requires": {
         "err-code": "^2.0.0",
-        "protons": "^2.0.0"
+        "protons": "^1.2.0"
+      }
+    },
+    "ipfs-unixfs-exporter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-2.0.2.tgz",
+      "integrity": "sha512-O4PknoOXzQKyAPFSZ+DCaPcSMmUnjPn2kxzhMGlWbXlUXkgGSs1cf3vcy16c/czF7DzVbQruhwURiR1IpUcYQA==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.6.0",
+        "cids": "^0.8.0",
+        "err-code": "^2.0.0",
+        "hamt-sharding": "^1.0.0",
+        "ipfs-unixfs": "^1.0.3",
+        "it-last": "^1.0.1",
+        "multihashing-async": "^0.8.0"
       },
       "dependencies": {
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
             "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
     },
-    "ipfs-unixfs-exporter": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-3.0.4.tgz",
-      "integrity": "sha512-e5rA97JeLaaCBOsuG62MJ2UJZQ3xgd8MoJpNotO37VDXRuE/X0/ny6N8AIxikZ8kHkNmCbclW+B5yQHcmqtRvA==",
-      "dev": true,
-      "requires": {
-        "cids": "^1.0.0",
-        "err-code": "^2.0.0",
-        "hamt-sharding": "^1.0.0",
-        "ipfs-unixfs": "^2.0.3",
-        "ipfs-utils": "^3.0.0",
-        "it-last": "^1.0.1",
-        "multihashing-async": "^2.0.0"
-      }
-    },
     "ipfs-unixfs-importer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-3.0.4.tgz",
-      "integrity": "sha512-2Lz1WSrmmMxBZzk99Uh1o76OZMWzkzgvSpcZcG8AdzpBDdjtsGWWED9FBuU31INT2dZk9Yszm8qxX3a8iYcXJg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-2.0.2.tgz",
+      "integrity": "sha512-VPi3zfNtTZZ22xECD2eY9c90tvzsan21z+8p+mG5U4inzUm+yBeWU8QCk9gzkHfrxAXaJO3VS8KOriFK+o0RGQ==",
       "dev": true,
       "requires": {
         "bl": "^4.0.0",
+        "buffer": "^5.6.0",
         "err-code": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "ipfs-unixfs": "^2.0.3",
-        "ipfs-utils": "^3.0.0",
-        "ipld-dag-pb": "^0.20.0",
+        "ipfs-unixfs": "^1.0.3",
+        "ipld-dag-pb": "^0.18.5",
         "it-all": "^1.0.1",
         "it-batch": "^1.0.3",
         "it-first": "^1.0.1",
         "it-parallel-batch": "^1.0.3",
         "merge-options": "^2.0.0",
-        "multihashing-async": "^2.0.0",
-        "rabin-wasm": "^0.1.1",
-        "uint8arrays": "^1.1.0"
+        "multihashing-async": "^0.8.0",
+        "rabin-wasm": "^0.1.1"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipfs-utils": {
@@ -9072,6 +9854,313 @@
         "temp-write": "^4.0.0"
       },
       "dependencies": {
+        "@hapi/accept": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
+          "integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/ammo": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+          "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/b64": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+          "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/boom": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+          "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/bounce": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+          "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/bourne": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+          "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+          "dev": true
+        },
+        "@hapi/call": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+          "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/catbox": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+          "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/podium": "4.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/catbox-memory": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
+          "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/content": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+          "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x"
+          }
+        },
+        "@hapi/cryptiles": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+          "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x"
+          }
+        },
+        "@hapi/file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+          "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
+          "dev": true
+        },
+        "@hapi/hapi": {
+          "version": "20.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.0.tgz",
+          "integrity": "sha512-Wh0tIDFsl7nemU2JQYW4zZVr9XkpuZ1eM3yaX8tzaYdaYXon8QeB5NzrTNQY3R1/+fO7amQUrOoLLNPRwIZfgw==",
+          "dev": true,
+          "requires": {
+            "@hapi/accept": "^5.0.1",
+            "@hapi/ammo": "^5.0.1",
+            "@hapi/boom": "9.x.x",
+            "@hapi/bounce": "2.x.x",
+            "@hapi/call": "8.x.x",
+            "@hapi/catbox": "^11.1.1",
+            "@hapi/catbox-memory": "5.x.x",
+            "@hapi/heavy": "^7.0.1",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/mimos": "5.x.x",
+            "@hapi/podium": "^4.1.1",
+            "@hapi/shot": "^5.0.1",
+            "@hapi/somever": "3.x.x",
+            "@hapi/statehood": "^7.0.3",
+            "@hapi/subtext": "^7.0.3",
+            "@hapi/teamwork": "5.x.x",
+            "@hapi/topo": "5.x.x",
+            "@hapi/validate": "^1.1.0"
+          }
+        },
+        "@hapi/heavy": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+          "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/hoek": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
+          "dev": true
+        },
+        "@hapi/iron": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+          "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+          "dev": true,
+          "requires": {
+            "@hapi/b64": "5.x.x",
+            "@hapi/boom": "9.x.x",
+            "@hapi/bourne": "2.x.x",
+            "@hapi/cryptiles": "5.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/mimos": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
+          "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "9.x.x",
+            "mime-db": "1.x.x"
+          }
+        },
+        "@hapi/nigel": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+          "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^9.0.4",
+            "@hapi/vise": "^4.0.0"
+          }
+        },
+        "@hapi/pez": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+          "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+          "dev": true,
+          "requires": {
+            "@hapi/b64": "5.x.x",
+            "@hapi/boom": "9.x.x",
+            "@hapi/content": "^5.0.2",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/nigel": "4.x.x"
+          }
+        },
+        "@hapi/podium": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.1.tgz",
+          "integrity": "sha512-jh7a6+5Z4FUWzx8fgmxjaAa1DTBu+Qfg+NbVdo0f++rE5DgsVidUYrLDp3db65+QjDLleA2MfKQXkpT8ylBDXA==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "9.x.x",
+            "@hapi/teamwork": "5.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/shot": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.4.tgz",
+          "integrity": "sha512-PcEz0WJgFDA3xNSMeONgQmothFr7jhbbRRSAKaDh7chN7zOXBlhl13bvKZW6CMb2xVfJUmt34CW3e/oExMgBhQ==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "9.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/somever": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
+          "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
+          "dev": true,
+          "requires": {
+            "@hapi/bounce": "2.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/statehood": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
+          "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/bounce": "2.x.x",
+            "@hapi/bourne": "2.x.x",
+            "@hapi/cryptiles": "5.x.x",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/iron": "6.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/subtext": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+          "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/bourne": "2.x.x",
+            "@hapi/content": "^5.0.2",
+            "@hapi/file": "2.x.x",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/pez": "^5.0.1",
+            "@hapi/wreck": "17.x.x"
+          }
+        },
+        "@hapi/teamwork": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
+          "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
+          "dev": true
+        },
+        "@hapi/topo": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "@hapi/vise": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+          "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/wreck": {
+          "version": "17.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
+          "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
+          "dev": true,
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/bourne": "2.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "cids": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-1.0.0.tgz",
+          "integrity": "sha512-HEBCIElSiXlkgZq3dgHJc3eDcnFteFp96N8/1/oqX5lkxBtB66sZ12jqEP3g7Ut++jEk6kIUGifQ1Qrya1jcNQ==",
+          "dev": true,
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashes": "^3.0.1",
+            "uint8arrays": "^1.0.0"
+          }
+        },
         "is-plain-obj": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -9086,188 +10175,706 @@
           "requires": {
             "is-plain-obj": "^2.1.0"
           }
+        },
+        "multiaddr": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.0.0.tgz",
+          "integrity": "sha512-4OOyr0u0i4lvh9MY/mvuCNmH5eqoTamcnGeXz6umFGc0eaVQUGPDQNbp52YfFY92NlZ76pO6h4K2HkXsT5X43w==",
+          "dev": true,
+          "requires": {
+            "cids": "^1.0.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^3.0.0",
+            "uint8arrays": "^1.1.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multicodec": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.1.tgz",
+          "integrity": "sha512-YDYeWn9iGa76hOHAyyZa0kbt3tr5FLg1ZXUHrZUJltjnxxdbTIbHnxWLd2zTcMOjdT3QyO+Xs4bQgJUcC2RWUA==",
+          "dev": true,
+          "requires": {
+            "uint8arrays": "1.0.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+              "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+              "dev": true,
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.2"
+              }
+            }
+          }
         }
       }
     },
     "ipld": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.27.1.tgz",
-      "integrity": "sha512-rX9TVFk9ZpMtjVdi74yaOgBcGRcz8NhGQHS4t/A4v/4UKp+nBWzDSMSAHpKXM1PGXYdlzYyIsfQMMoimQXVTxw==",
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.26.4.tgz",
+      "integrity": "sha512-beRa9tayJDbzlqA7UEnUXQq654dAgnsrTSIJIe/vOBJToH8lDc/pLuIOmPYrDCVlv6XtJuZ7qgk3bIPppb21dA==",
       "dev": true,
       "requires": {
-        "cids": "^1.0.0",
-        "ipld-block": "^0.10.0",
-        "ipld-dag-cbor": "^0.17.0",
-        "ipld-dag-pb": "^0.20.0",
-        "ipld-raw": "^6.0.0",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
+        "ipld-block": "^0.9.1",
+        "ipld-dag-cbor": "^0.16.0",
+        "ipld-dag-pb": "^0.19.0",
+        "ipld-raw": "^5.0.0",
         "merge-options": "^2.0.0",
-        "multicodec": "^2.0.0",
+        "multicodec": "^1.0.0",
         "typical": "^6.0.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
+          "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "cids": "~0.8.3",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.3",
+            "multihashing-async": "^1.0.0",
+            "protons": "^1.2.1",
+            "stable": "^0.1.8"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipld-bitcoin": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.4.0.tgz",
-      "integrity": "sha512-SRcNRMvdeIKlCCMymqas5ZX9tVjAZ/cid2LPd0vWrLtwc1r4liWvHAxbaU/fJa8Xo6neYWuS/XIqaE/yzMAhRw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.3.2.tgz",
+      "integrity": "sha512-cglP2KmfpQK6UWR6Yu4+F2Aj8z5m3z/ng4Bq2FV9rxASGSQn1nmVRFQu39j2lYcEUrvPPc+HRsDz1Ppvd6xODQ==",
       "dev": true,
       "requires": {
         "bitcoinjs-lib": "^5.0.0",
         "buffer": "^5.6.0",
-        "cids": "^1.0.0",
-        "multicodec": "^2.0.0",
-        "multihashes": "^3.0.0",
-        "multihashing-async": "^2.0.0",
-        "uint8arrays": "^1.0.0"
+        "cids": "^0.8.3",
+        "multicodec": "^1.0.0",
+        "multihashes": "^1.0.1",
+        "multihashing-async": "^1.0.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipld-block": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.10.1.tgz",
-      "integrity": "sha512-lPMfW9tA2hVZw9hdO/YSppTxFmA0+5zxcefBOlCTOn+12RLyy+pdepKMbQw8u0KESFu3pYVmabNRWuFGcgHLLw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.9.2.tgz",
+      "integrity": "sha512-/i99foB+QI8WhyZWu6ZVPFw2sP6kzZSnnjPNlxxrgaJeFX22w2z00nYWafY2YYYP4mZ9xkLZDSS/msli7XXyvw==",
       "dev": true,
       "requires": {
-        "cids": "^1.0.0",
+        "buffer": "^5.5.0",
+        "cids": "~0.8.0",
         "class-is": "^1.1.0"
-      }
-    },
-    "ipld-dag-cbor": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.17.0.tgz",
-      "integrity": "sha512-YprSTQClJQUyC+RhbWrVXhg7ysII5R/jrmZZ4en4n9Mav+MRbntAW699zd1PHRLB71lNCJbxABE2Uc9QU2Ka7g==",
-      "dev": true,
-      "requires": {
-        "borc": "^2.1.2",
-        "cids": "^1.0.0",
-        "is-circular": "^1.0.2",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.0",
-        "uint8arrays": "^1.0.0"
-      }
-    },
-    "ipld-dag-pb": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.20.0.tgz",
-      "integrity": "sha512-zfM0EdaolqNjAxIrtpuGKvXxWk5YtH9jKinBuQGTcngOsWFQhyybGCTJHGNGGtRjHNJi2hz5Udy/8pzv4kcKyg==",
-      "requires": {
-        "cids": "^1.0.0",
-        "class-is": "^1.1.0",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.0",
-        "protons": "^2.0.0",
-        "reset": "^0.1.0",
-        "run": "^1.4.0",
-        "stable": "^0.1.8",
-        "uint8arrays": "^1.0.0"
       },
       "dependencies": {
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
           "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
             "varint": "^5.0.0"
           }
         }
       }
     },
+    "ipld-dag-cbor": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.16.0.tgz",
+      "integrity": "sha512-dnmR8Pgt1gGmEXWSf/V3dKDPveGnHsovvAAN7m/WHW5mXsBqYYOStt98K1RhCifbB7vY+IHmpdRhVka0g9DWFQ==",
+      "dev": true,
+      "requires": {
+        "borc": "^2.1.2",
+        "buffer": "^5.6.0",
+        "cids": "~0.8.3",
+        "is-circular": "^1.0.2",
+        "multicodec": "^1.0.3",
+        "multihashing-async": "^1.0.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
+      }
+    },
+    "ipld-dag-pb": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
+      "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
+      "requires": {
+        "buffer": "^5.6.0",
+        "cids": "~0.8.0",
+        "class-is": "^1.1.0",
+        "multicodec": "^1.0.1",
+        "multihashing-async": "~0.8.1",
+        "protons": "^1.0.2",
+        "stable": "^0.1.8"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
+      }
+    },
     "ipld-ethereum": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-5.0.1.tgz",
-      "integrity": "sha512-M0n4z4y0LwsBKIvQev8xHOfxwjwR+jl6ot8z2ujScE6MX+inhojw2/vjvoWIk4N7oleNf3sg4ZxBzdttulvPTA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-4.0.2.tgz",
+      "integrity": "sha512-0uShqn7PcCgWca7lkn8WE8sS8GVDxoi7+juiSLw2MApx+r11hPBjiMDKy0SFZoyXMRYPZA6Xh1WTqzH8UM2eHA==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "^1.0.0",
+        "cids": "^0.8.3",
         "ethereumjs-account": "^3.0.0",
         "ethereumjs-block": "^2.2.1",
         "ethereumjs-tx": "^2.1.1",
         "merkle-patricia-tree": "^3.0.0",
-        "multicodec": "^2.0.0",
-        "multihashes": "^3.0.1",
-        "multihashing-async": "^2.0.0",
+        "multicodec": "^1.0.0",
+        "multihashes": "^1.0.1",
+        "multihashing-async": "^1.0.0",
         "rlp": "^2.2.4"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipld-git": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.6.1.tgz",
-      "integrity": "sha512-HjKjmMX8vIEMk+isMBaU0/g+xi6LZOQHQ7oFaQ15wUUYLWe5rwkpdr8/3GqHEt3hKdEeWDCX2FqrmQsT9lrQFA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.5.3.tgz",
+      "integrity": "sha512-ffJgkGFb7VnTh8AOZNu19de1pXecbInJ62iEfL1ydn330tgwWtSMI2ny2EXGuOg1LvR9DF87Shz92CdtW4zYTw==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "^1.0.0",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.1",
+        "cids": "^0.8.3",
+        "multicodec": "^1.0.2",
+        "multihashing-async": "^1.0.0",
         "smart-buffer": "^4.1.0",
-        "strftime": "^0.10.0",
-        "uint8arrays": "^1.0.0"
+        "strftime": "^0.10.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipld-raw": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-6.0.0.tgz",
-      "integrity": "sha512-UK7fjncAzs59iu/o2kwYtb8jgTtW6B+cNWIiNpAJkfRwqoMk1xD/6i25ktzwe4qO8gQgoR9RxA5ibC23nq8BLg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-5.0.0.tgz",
+      "integrity": "sha512-z1Fie224lTtQZbFg+wC5WDY692G3SIpO8vT86yCU83vqpIvasVuV3SzDSv7G36kRxP03PPZOkvKAOFrcjb7gpw==",
       "dev": true,
       "requires": {
-        "cids": "^1.0.0",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.0"
+        "cids": "~0.8.0",
+        "multicodec": "^1.0.1",
+        "multihashing-async": "~0.8.1"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipld-zcash": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.5.0.tgz",
-      "integrity": "sha512-nBeyZ/g/hvP3FQl9IODe6mW+UoO10hQMb3k9elcAuwfromljE/rozoDMiMYagZAm03dkSHsk/YSeEWdWqRKaPQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.4.3.tgz",
+      "integrity": "sha512-HBczqYbhRWOGmq4kcLnD9W8sM5BBJPGTH/hHia4b97BpF1JYDCu+vDv8xrJUAj6l+o+VX4xs+S50tMMEDEhXXA==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "^1.0.0",
-        "multicodec": "^2.0.0",
-        "multihashes": "^3.0.1",
-        "multihashing-async": "^2.0.0",
+        "cids": "^0.8.3",
+        "multicodec": "^1.0.0",
+        "multihashes": "^1.0.1",
+        "multihashing-async": "^1.0.0",
         "zcash-block": "^2.0.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipns": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.8.0.tgz",
-      "integrity": "sha512-DbveKyLuiO6GgZ4lILxQ3h+27dV/5MPriDTDny3/WHEaCOYH8Gs64CRP5MBQPQcsnZ2Tg+YkjnUAKX/pWAwNhA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.7.4.tgz",
+      "integrity": "sha512-M1yX3oU5NSTC1fRb7GFs3RZk9b7bKxtPfDLRO5ezOVaqviTWNsZerMi/AueD9HuwTMVRhFQODRXnsOWntU0oBg==",
       "dev": true,
       "requires": {
+        "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "interface-datastore": "^2.0.0",
-        "libp2p-crypto": "^0.18.0",
+        "interface-datastore": "^1.0.2",
+        "libp2p-crypto": "^0.17.1",
         "multibase": "^3.0.0",
         "multihashes": "^3.0.1",
-        "peer-id": "^0.14.0",
-        "protons": "^2.0.0",
-        "timestamp-nano": "^1.0.0",
-        "uint8arrays": "^1.1.0"
+        "peer-id": "^0.13.6",
+        "protons": "^1.0.1",
+        "timestamp-nano": "^1.0.0"
       },
       "dependencies": {
         "libp2p-crypto": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
-          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
           "dev": true,
           "requires": {
+            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^2.0.0",
+            "protons": "^1.2.1",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.1.0",
+            "uint8arrays": "^1.0.0",
             "ursa-optional": "^0.10.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "multihashes": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.6.0",
+                "multibase": "^1.0.1",
+                "varint": "^5.0.0"
+              }
+            }
           }
         },
         "node-gyp-build": {
@@ -9275,18 +10882,6 @@
           "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
           "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
-        },
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
-          "dev": true,
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
-            "varint": "^5.0.0"
-          }
         },
         "secp256k1": {
           "version": "4.0.2",
@@ -9338,9 +10933,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.1.tgz",
+      "integrity": "sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg==",
       "dev": true
     },
     "is-ci": {
@@ -9475,18 +11070,77 @@
       }
     },
     "is-ipfs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-2.0.0.tgz",
-      "integrity": "sha512-X4Cg/JO+h/ygBCrIQSMgicHRLo5QpB+i5tHLhFgGBksKi3zvX6ByFCshDxNBvcq4NFxF3coI2AaLqwzugNzKcw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-1.0.3.tgz",
+      "integrity": "sha512-7SAfhxp39rxMvr95qjHMtsle1xa7zXpIbhX/Q77iXKtMVnQ0Fr9AVpAUq+bl3HPXGXDpZJFP0hzWBZaMwD6vGg==",
       "dev": true,
       "requires": {
-        "cids": "^1.0.0",
+        "buffer": "^5.6.0",
+        "cids": "~0.8.0",
         "iso-url": "~0.4.7",
-        "mafmt": "^8.0.0",
-        "multiaddr": "^8.0.0",
-        "multibase": "^3.0.0",
-        "multihashes": "^3.0.1",
-        "uint8arrays": "^1.1.0"
+        "mafmt": "^7.1.0",
+        "multiaddr": "^7.4.3",
+        "multibase": "~0.7.0",
+        "multihashes": "~0.4.19"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "multihashes": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.6.0",
+                "multibase": "^1.0.1",
+                "varint": "^5.0.0"
+              }
+            }
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        }
       }
     },
     "is-map": {
@@ -10074,6 +11728,44 @@
         "@hapi/hoek": "^9.0.0",
         "@hapi/pinpoint": "^2.0.0",
         "@hapi/topo": "^5.0.0"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+          "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "@hapi/formula": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+          "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
+          "dev": true
+        },
+        "@hapi/hoek": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
+          "dev": true
+        },
+        "@hapi/pinpoint": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+          "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==",
+          "dev": true
+        },
+        "@hapi/topo": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        }
       }
     },
     "joycon": {
@@ -10837,9 +12529,9 @@
       }
     },
     "libp2p": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.29.0.tgz",
-      "integrity": "sha512-eALoJ0vpsonRwzLpdPY2/272RIl2MImIg2QToqLb+wBChcSQFB4U/r3LU8rZqEaDfRNupOBG/rx67gJTWC0h2Q==",
+      "version": "0.28.10",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.28.10.tgz",
+      "integrity": "sha512-0WR86vPj3RIEP7jFWBy1J4GBp8wweC1pmzy5nfKZazP22wA/crqqnxcr4xGs/7lzFyfBJuqRIswz3/IrlgO+ag==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -10851,7 +12543,7 @@
         "err-code": "^2.0.0",
         "events": "^3.1.0",
         "hashlru": "^2.3.0",
-        "interface-datastore": "^2.0.0",
+        "interface-datastore": "^1.0.4",
         "ipfs-utils": "^2.2.0",
         "it-all": "^1.0.1",
         "it-buffer": "^0.1.2",
@@ -10859,27 +12551,25 @@
         "it-length-prefixed": "^3.0.1",
         "it-pipe": "^1.1.0",
         "it-protocol-buffers": "^0.2.0",
-        "libp2p-crypto": "^0.18.0",
-        "libp2p-interfaces": "^0.5.1",
-        "libp2p-utils": "^0.2.0",
-        "mafmt": "^8.0.0",
+        "libp2p-crypto": "^0.17.9",
+        "libp2p-interfaces": "^0.3.1",
+        "libp2p-utils": "^0.1.2",
+        "mafmt": "^7.0.0",
         "merge-options": "^2.0.0",
         "moving-average": "^1.0.0",
-        "multiaddr": "^8.0.0",
-        "multicodec": "^2.0.0",
-        "multistream-select": "^1.0.0",
+        "multiaddr": "^7.4.3",
+        "multistream-select": "^0.15.0",
         "mutable-proxy": "^1.0.0",
         "node-forge": "^0.9.1",
         "p-any": "^3.0.0",
         "p-fifo": "^1.0.0",
         "p-settle": "^4.0.1",
-        "peer-id": "^0.14.0",
-        "protons": "^2.0.0",
+        "peer-id": "^0.13.11",
+        "protons": "^1.0.1",
         "retimer": "^2.0.0",
         "sanitize-filename": "^1.6.3",
-        "streaming-iterables": "^5.0.2",
-        "timeout-abort-controller": "^1.1.1",
-        "varint": "^5.0.0",
+        "streaming-iterables": "^4.1.0",
+        "timeout-abort-controller": "^1.0.0",
         "xsalsa20": "^1.0.2"
       },
       "dependencies": {
@@ -10905,59 +12595,60 @@
           }
         },
         "libp2p-crypto": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
-          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
           "dev": true,
           "requires": {
+            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^2.0.0",
+            "protons": "^1.2.1",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.1.0",
+            "uint8arrays": "^1.0.0",
             "ursa-optional": "^0.10.1"
           }
         },
-        "libp2p-interfaces": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
-          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
           "dev": true,
           "requires": {
-            "abort-controller": "^3.0.0",
-            "abortable-iterator": "^3.0.0",
-            "chai": "^4.2.0",
-            "chai-checkmark": "^1.0.1",
-            "class-is": "^1.1.0",
-            "debug": "^4.1.1",
-            "delay": "^4.3.0",
-            "detect-node": "^2.0.4",
-            "dirty-chai": "^2.0.1",
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
             "err-code": "^2.0.0",
-            "it-goodbye": "^2.0.1",
-            "it-length-prefixed": "^3.1.0",
-            "it-pair": "^1.0.0",
-            "it-pipe": "^1.1.0",
-            "it-pushable": "^1.4.0",
-            "libp2p-crypto": "^0.18.0",
-            "libp2p-tcp": "^0.15.0",
-            "multiaddr": "^8.0.0",
-            "multibase": "^3.0.0",
-            "p-defer": "^3.0.0",
-            "p-limit": "^2.3.0",
-            "p-wait-for": "^3.1.0",
-            "peer-id": "^0.14.0",
-            "protons": "^2.0.0",
-            "sinon": "^9.0.2",
-            "streaming-iterables": "^5.0.2",
-            "uint8arrays": "^1.1.0"
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         },
         "node-gyp-build": {
@@ -10965,18 +12656,6 @@
           "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
           "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
-        },
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
-          "dev": true,
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
-            "varint": "^5.0.0"
-          }
         },
         "secp256k1": {
           "version": "4.0.2",
@@ -10988,19 +12667,25 @@
             "node-addon-api": "^2.0.0",
             "node-gyp-build": "^4.2.0"
           }
+        },
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+          "dev": true
         }
       }
     },
     "libp2p-bootstrap": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.12.1.tgz",
-      "integrity": "sha512-atHXxfxE8isHb+XKHsJ5UgFMteqfi0Xal94h+2EAJmobXcIq1mBMUeIgmkHMsaZZNwJwQxq6MKFthJngWJ8vEw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.11.0.tgz",
+      "integrity": "sha512-vLMmCJsecnHdR9pPUxvOimtnZdOfGXv4EImNB+Y0DKX3LUSyzb868N5oWCGhKMxDwt2Nm6/7Vl/Vd+eHnsU79g==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "mafmt": "^8.0.0",
-        "multiaddr": "^8.0.0",
-        "peer-id": "^0.14.0"
+        "mafmt": "^7.0.0",
+        "multiaddr": "^7.2.1",
+        "peer-id": "^0.13.5"
       }
     },
     "libp2p-crypto": {
@@ -11106,238 +12791,69 @@
       }
     },
     "libp2p-delegated-content-routing": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.7.0.tgz",
-      "integrity": "sha512-eyh6ckCJvAuH+dSI6lKrZ6JLdxazpPUpd2NbRcgmgb6sfpTyFaxhqMa5FHz304mX2FsvE3pX91pTShcL9Aitjg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.5.0.tgz",
+      "integrity": "sha512-ag5gt752n0TynbRsQN1JMF0FzSdMpHOprNdVm6vq/rsz/8wMGh9WxN+a1Zp9VoPp5rGHe7LTom13ziFf1Z/Nyg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "it-all": "^1.0.0",
-        "multiaddr": "^8.0.0",
+        "multiaddr": "^7.4.3",
         "p-defer": "^3.0.0",
         "p-queue": "^6.2.1"
       }
     },
     "libp2p-delegated-peer-routing": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/libp2p-delegated-peer-routing/-/libp2p-delegated-peer-routing-0.7.0.tgz",
-      "integrity": "sha512-bdSnCRts+AMlUv592ZITot+vels1UYQc4WMg8/y+gur1ifEE6GeGWnxneJyCuuzrrjmo2Svr4yY72kuMev+wVQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/libp2p-delegated-peer-routing/-/libp2p-delegated-peer-routing-0.5.0.tgz",
+      "integrity": "sha512-crnVXH56bTj0hqqsEb4xmfrZrdIxOBqnFp2D19inxTVwZtpg/Je1XJZDGSG2JJ2EnXxFGTNPFHcB5AIm8avDEg==",
       "dev": true,
       "requires": {
-        "cids": "^1.0.0",
         "debug": "^4.1.1",
-        "p-defer": "^3.0.0",
         "p-queue": "^6.3.0",
-        "peer-id": "^0.14.0"
+        "peer-id": "^0.13.11"
       }
     },
     "libp2p-floodsub": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.23.1.tgz",
-      "integrity": "sha512-d5Hl055SV3bkJ2u+bsRp+iWBsg1rVq2CehW2TYq4zoIp/bCGQyY/oQF6NzqnysKloElgRACfWOa/oQBRaSZFng==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.21.3.tgz",
+      "integrity": "sha512-TTehsDd5kZos27qmugmviF9GvzfyH8Tq2/YNBpp7Ku1KoSZugcdQAhz8hmStMtMGDkW5ysoKSBG739IhHUtgdg==",
       "dev": true,
       "requires": {
+        "async.nexttick": "^0.5.2",
+        "buffer": "^5.6.0",
         "debug": "^4.1.1",
-        "libp2p-interfaces": "^0.5.1",
-        "time-cache": "^0.3.0",
-        "uint8arrays": "^1.1.0"
-      },
-      "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
-          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
-          "dev": true,
-          "requires": {
-            "err-code": "^2.0.0",
-            "is-typedarray": "^1.0.0",
-            "iso-random-stream": "^1.1.0",
-            "keypair": "^1.0.1",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.1",
-            "node-forge": "^0.9.1",
-            "pem-jwk": "^2.0.0",
-            "protons": "^2.0.0",
-            "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.1.0",
-            "ursa-optional": "^0.10.1"
-          }
-        },
-        "libp2p-interfaces": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
-          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "abortable-iterator": "^3.0.0",
-            "chai": "^4.2.0",
-            "chai-checkmark": "^1.0.1",
-            "class-is": "^1.1.0",
-            "debug": "^4.1.1",
-            "delay": "^4.3.0",
-            "detect-node": "^2.0.4",
-            "dirty-chai": "^2.0.1",
-            "err-code": "^2.0.0",
-            "it-goodbye": "^2.0.1",
-            "it-length-prefixed": "^3.1.0",
-            "it-pair": "^1.0.0",
-            "it-pipe": "^1.1.0",
-            "it-pushable": "^1.4.0",
-            "libp2p-crypto": "^0.18.0",
-            "libp2p-tcp": "^0.15.0",
-            "multiaddr": "^8.0.0",
-            "multibase": "^3.0.0",
-            "p-defer": "^3.0.0",
-            "p-limit": "^2.3.0",
-            "p-wait-for": "^3.1.0",
-            "peer-id": "^0.14.0",
-            "protons": "^2.0.0",
-            "sinon": "^9.0.2",
-            "streaming-iterables": "^5.0.2",
-            "uint8arrays": "^1.1.0"
-          }
-        },
-        "node-gyp-build": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-          "dev": true
-        },
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
-          "dev": true,
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "secp256k1": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-          "dev": true,
-          "requires": {
-            "elliptic": "^6.5.2",
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
+        "it-length-prefixed": "^3.0.0",
+        "it-pipe": "^1.0.1",
+        "libp2p-pubsub": "~0.5.2",
+        "p-map": "^4.0.0",
+        "peer-id": "~0.13.3",
+        "protons": "^1.0.1",
+        "time-cache": "^0.3.0"
       }
     },
     "libp2p-gossipsub": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.6.1.tgz",
-      "integrity": "sha512-gwmRlS//Zz1nYuq4BfOsV3yg27i++uXihnteF5RztqRz6FqrRd0JsID32HtzD+LQ93PGTB457sxuOOpDvXLapQ==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.4.7.tgz",
+      "integrity": "sha512-TW5uC3afNpDSp9Dm2K9zPa9Lfjjgm5UAVQPC1gWEm7VINBGZ/az54088UAL+S4RPMg9xykJX6Cn0wk07Wd0r5A==",
       "dev": true,
       "requires": {
-        "@types/debug": "^4.1.5",
+        "buffer": "^5.6.0",
         "debug": "^4.1.1",
-        "denque": "^1.4.1",
         "err-code": "^2.0.0",
+        "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.0.1",
-        "libp2p-interfaces": "^0.5.1",
-        "peer-id": "^0.14.0",
-        "protons": "^2.0.0",
+        "libp2p-pubsub": "~0.5.2",
+        "p-map": "^4.0.0",
+        "peer-id": "~0.13.12",
+        "protons": "^1.0.1",
         "time-cache": "^0.3.0"
-      },
-      "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
-          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
-          "dev": true,
-          "requires": {
-            "err-code": "^2.0.0",
-            "is-typedarray": "^1.0.0",
-            "iso-random-stream": "^1.1.0",
-            "keypair": "^1.0.1",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.1",
-            "node-forge": "^0.9.1",
-            "pem-jwk": "^2.0.0",
-            "protons": "^2.0.0",
-            "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.1.0",
-            "ursa-optional": "^0.10.1"
-          }
-        },
-        "libp2p-interfaces": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
-          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "abortable-iterator": "^3.0.0",
-            "chai": "^4.2.0",
-            "chai-checkmark": "^1.0.1",
-            "class-is": "^1.1.0",
-            "debug": "^4.1.1",
-            "delay": "^4.3.0",
-            "detect-node": "^2.0.4",
-            "dirty-chai": "^2.0.1",
-            "err-code": "^2.0.0",
-            "it-goodbye": "^2.0.1",
-            "it-length-prefixed": "^3.1.0",
-            "it-pair": "^1.0.0",
-            "it-pipe": "^1.1.0",
-            "it-pushable": "^1.4.0",
-            "libp2p-crypto": "^0.18.0",
-            "libp2p-tcp": "^0.15.0",
-            "multiaddr": "^8.0.0",
-            "multibase": "^3.0.0",
-            "p-defer": "^3.0.0",
-            "p-limit": "^2.3.0",
-            "p-wait-for": "^3.1.0",
-            "peer-id": "^0.14.0",
-            "protons": "^2.0.0",
-            "sinon": "^9.0.2",
-            "streaming-iterables": "^5.0.2",
-            "uint8arrays": "^1.1.0"
-          }
-        },
-        "node-gyp-build": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-          "dev": true
-        },
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
-          "dev": true,
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "secp256k1": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-          "dev": true,
-          "requires": {
-            "elliptic": "^6.5.2",
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
       }
     },
     "libp2p-interfaces": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.4.1.tgz",
-      "integrity": "sha512-LvoK21WtoRxmdLFWGGKMomK4SLXSqcyntoCQ254IOao/EOjis0Za09THENjK+pL1Lk84D1tXLwwK+8pT19EWDw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.3.2.tgz",
+      "integrity": "sha512-EZviUYO5d4T/mYwDFMC/tVvLiS95+Ui8agn/DovsnUhlYPojLJJNapEJYFqFbgKqP+dxpMVMZ5CyJXD334qsuA==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -11353,72 +12869,121 @@
         "it-goodbye": "^2.0.1",
         "it-pair": "^1.0.0",
         "it-pipe": "^1.1.0",
-        "libp2p-tcp": "^0.15.0",
-        "multiaddr": "^8.0.0",
+        "libp2p-tcp": "^0.14.5",
+        "multiaddr": "^7.5.0",
         "p-defer": "^3.0.0",
         "p-limit": "^2.3.0",
         "p-wait-for": "^3.1.0",
-        "peer-id": "^0.14.0",
+        "peer-id": "^0.13.13",
         "sinon": "^9.0.2",
         "streaming-iterables": "^5.0.2"
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.20.1.tgz",
-      "integrity": "sha512-khffe6L6O6oU53LO8BrI3bULH4i6FLibvFEyV+7FAPXnFYhTKHa9TsIifkL/MEAfLI0hI9QN4NwMf0DpOLMvDA==",
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.19.9.tgz",
+      "integrity": "sha512-nbXkusPRpWoLc89/6eGV+IrE105kcWUE/cUAJtaAPUFpuSonKk+TPYfsAJnYhX93y7JA8XGXZfuPDJbHIo7Qnw==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "async": "^2.6.2",
         "base32.js": "~0.1.0",
-        "cids": "^1.0.0",
+        "buffer": "^5.6.0",
+        "cids": "~0.8.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
         "hashlru": "^2.3.0",
         "heap": "~0.2.6",
-        "interface-datastore": "^2.0.0",
+        "interface-datastore": "^1.0.2",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.1.0",
         "k-bucket": "^5.0.0",
-        "libp2p-crypto": "^0.18.0",
-        "libp2p-interfaces": "^0.4.0",
-        "libp2p-record": "^0.9.0",
-        "multiaddr": "^8.0.0",
-        "multihashing-async": "^2.0.1",
+        "libp2p-crypto": "~0.17.1",
+        "libp2p-interfaces": "^0.3.0",
+        "libp2p-record": "~0.7.0",
+        "multiaddr": "^7.4.3",
+        "multihashing-async": "^0.8.2",
         "p-filter": "^2.1.0",
         "p-map": "^4.0.0",
         "p-queue": "^6.2.1",
         "p-timeout": "^3.2.0",
         "p-times": "^3.0.0",
-        "peer-id": "^0.14.0",
+        "peer-id": "~0.13.5",
         "promise-to-callback": "^1.0.0",
-        "protons": "^2.0.0",
-        "streaming-iterables": "^5.0.2",
-        "uint8arrays": "^1.1.0",
+        "protons": "^1.0.1",
+        "streaming-iterables": "^4.1.1",
         "varint": "^5.0.0",
         "xor-distance": "^2.0.0"
       },
       "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
-          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^2.0.0",
+            "protons": "^1.2.1",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.1.0",
+            "uint8arrays": "^1.0.0",
             "ursa-optional": "^0.10.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         },
         "node-gyp-build": {
@@ -11427,17 +12992,134 @@
           "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
         },
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
+        "secp256k1": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
           "dev": true,
           "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
+            "elliptic": "^6.5.2",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
+        },
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+          "dev": true
+        }
+      }
+    },
+    "libp2p-mdns": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.14.3.tgz",
+      "integrity": "sha512-NxGFh469olcTr/AJ43BSmcAa5tvM6bXLXS54dq3Lw5IEeqr2JrTbxkcl+evFu3caKe/p+bN4c5kH7hGDZX6+yQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "multiaddr": "^7.5.0",
+        "multicast-dns": "^7.2.0",
+        "peer-id": "^0.13.13"
+      }
+    },
+    "libp2p-mplex": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.9.5.tgz",
+      "integrity": "sha512-3YHtuhE5GWtWzsvz3zIwZMLHxMcwpPnI2HgT/FZzvi8kYF00Y6psZtzC9p+yDiu9deeq5ZlmcbKzKA36k8VoSQ==",
+      "dev": true,
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "abortable-iterator": "^3.0.0",
+        "bl": "^4.0.0",
+        "buffer": "^5.5.0",
+        "debug": "^4.1.1",
+        "it-pipe": "^1.0.1",
+        "it-pushable": "^1.3.1",
+        "varint": "^5.0.0"
+      }
+    },
+    "libp2p-noise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/libp2p-noise/-/libp2p-noise-1.1.2.tgz",
+      "integrity": "sha512-iKXdzGnPsz3slh6Gm9oNj0h0X37f/YFuSkg7MikQgrx5l5XRaFRxVDoqbsTlQ5nIS02tGuLJvmbqpLOZ+aWVow==",
+      "dev": true,
+      "requires": {
+        "bcrypto": "5.1.0",
+        "buffer": "^5.4.3",
+        "debug": "^4.1.1",
+        "it-buffer": "^0.1.1",
+        "it-length-prefixed": "^3.0.0",
+        "it-pair": "^1.0.0",
+        "it-pb-rpc": "^0.1.8",
+        "it-pipe": "^1.1.0",
+        "libp2p-crypto": "^0.17.6",
+        "peer-id": "^0.13.5",
+        "protobufjs": "6.8.8"
+      },
+      "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "^0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.2.1",
+            "secp256k1": "^4.0.0",
             "uint8arrays": "^1.0.0",
+            "ursa-optional": "^0.10.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
             "varint": "^5.0.0"
           }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+          "dev": true
         },
         "secp256k1": {
           "version": "4.0.2",
@@ -11452,72 +13134,103 @@
         }
       }
     },
-    "libp2p-mdns": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.15.0.tgz",
-      "integrity": "sha512-wuILE+mwC6ww/0TMkR3k2h53D5Ma9TXpz0siacbsACcGukkS+mIpsvruaf9U1Uxe0F1aC8+Y+Vi5lP8C3YR9Lg==",
+    "libp2p-pubsub": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.5.6.tgz",
+      "integrity": "sha512-1nQ709amKckPOcK7nZZom66PZytn8VIdR9BxpxhXxwmMmeuCIUKB+65UK7tI07M4LrcWsWPwZH6PbQBKiQ+Fzw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "multiaddr": "^8.0.0",
-        "multicast-dns": "^7.2.0",
-        "peer-id": "^0.14.0"
-      }
-    },
-    "libp2p-mplex": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.10.0.tgz",
-      "integrity": "sha512-q+zpo12ldm8E+AlnR/LK/j++MM8IkDHi/P19VMPWP07irXe1Pmy/lw6IrSqtDOD8KQc86ipib9d1PI3ALdN8vA==",
-      "dev": true,
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "abortable-iterator": "^3.0.0",
-        "bl": "^4.0.0",
-        "debug": "^4.1.1",
-        "it-pipe": "^1.0.1",
-        "it-pushable": "^1.3.1",
-        "varint": "^5.0.0"
-      }
-    },
-    "libp2p-noise": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/libp2p-noise/-/libp2p-noise-2.0.0.tgz",
-      "integrity": "sha512-EhHU8TaPw0JDMakPFpOTsfDrKYvBc/MsvUpQy3GECAcAJEu+gBW6CYYqJqMx/ZXnr/QBUeZfnOXBVlbTnEJ/7g==",
-      "dev": true,
-      "requires": {
-        "bcrypto": "^5.2.0",
-        "buffer": "^5.4.3",
-        "debug": "^4.1.1",
-        "it-buffer": "^0.1.1",
+        "err-code": "^2.0.0",
         "it-length-prefixed": "^3.0.0",
-        "it-pair": "^1.0.0",
-        "it-pb-rpc": "^0.1.8",
-        "it-pipe": "^1.1.0",
-        "libp2p-crypto": "^0.18.0",
-        "peer-id": "^0.14.0",
-        "protobufjs": "^6.10.1",
-        "uint8arrays": "^1.1.0"
+        "it-pipe": "^1.0.1",
+        "it-pushable": "^1.3.2",
+        "libp2p-crypto": "~0.17.0",
+        "libp2p-interfaces": "^0.3.0",
+        "multibase": "^0.7.0",
+        "peer-id": "~0.13.3",
+        "protons": "^1.0.1"
       },
       "dependencies": {
         "libp2p-crypto": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
-          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
           "dev": true,
           "requires": {
+            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^2.0.0",
+            "protons": "^1.2.1",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.1.0",
+            "uint8arrays": "^1.0.0",
             "ursa-optional": "^0.10.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         },
         "node-gyp-build": {
@@ -11525,18 +13238,6 @@
           "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
           "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
-        },
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
-          "dev": true,
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
-            "varint": "^5.0.0"
-          }
         },
         "secp256k1": {
           "version": "4.0.2",
@@ -11552,36 +13253,82 @@
       }
     },
     "libp2p-record": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.9.0.tgz",
-      "integrity": "sha512-8FlhzP+UlXTYOR+9D8nYoGOIJ6S8XogKD625bqzHJbXJQyJNCNaW3tZPHqrQrvUW7o6GsAeyQAfCp5WLEH0FZg==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.7.3.tgz",
+      "integrity": "sha512-a6MrDeVqIkAUaDaiS3vWFu2OblpuBaBmY3bfQY+ZcEI/C2lWB0MixIby9RhrTmR+rqM+W3yoDLQa+clm1HVLhw==",
       "dev": true,
       "requires": {
+        "buffer": "^5.6.0",
         "err-code": "^2.0.0",
-        "multihashes": "^3.0.1",
-        "multihashing-async": "^2.0.1",
-        "protons": "^2.0.0",
-        "uint8arrays": "^1.1.0"
+        "multihashes": "~0.4.15",
+        "multihashing-async": "^0.8.0",
+        "protons": "^1.0.1"
       },
       "dependencies": {
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
           "dev": true,
           "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
             "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "multihashes": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.6.0",
+                "multibase": "^1.0.1",
+                "varint": "^5.0.0"
+              }
+            }
           }
         }
       }
     },
     "libp2p-secio": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.13.1.tgz",
-      "integrity": "sha512-1rJBqaCTeKAyA1BedfGCjG8SKB+fOqWXPJLklkaRBcdwmtoNdvCLuLt5So81Z/5sqrbETM1vAQRVdMpyTfPrKw==",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.12.6.tgz",
+      "integrity": "sha512-SPuXcQsXXix7Lkmx5fv+woKay+DWycFxv7xkWi+8CD5oa15/4U1E8qqqnE7Lwjj2Ub1i0DuE74GRRzap46sxTQ==",
       "dev": true,
       "requires": {
         "bl": "^4.0.0",
@@ -11590,34 +13337,97 @@
         "it-pair": "^1.0.0",
         "it-pb-rpc": "^0.1.4",
         "it-pipe": "^1.1.0",
-        "libp2p-crypto": "^0.18.0",
-        "libp2p-interfaces": "^0.4.0",
-        "multiaddr": "^8.0.0",
-        "multihashing-async": "^2.0.1",
-        "peer-id": "^0.14.0",
-        "protons": "^2.0.0",
-        "uint8arrays": "^1.1.0"
+        "libp2p-crypto": "^0.17.3",
+        "libp2p-interfaces": "^0.2.1",
+        "multiaddr": "^7.2.1",
+        "multihashing-async": "^0.8.0",
+        "peer-id": "^0.13.6",
+        "protons": "^1.0.2"
       },
       "dependencies": {
         "libp2p-crypto": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
-          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
           "dev": true,
           "requires": {
+            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^2.0.0",
+            "protons": "^1.2.1",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.1.0",
+            "uint8arrays": "^1.0.0",
             "ursa-optional": "^0.10.1"
+          }
+        },
+        "libp2p-interfaces": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.2.8.tgz",
+          "integrity": "sha512-Uzjlzbjk7Bx9giSU2z3qbQv/N8iV9ARL7GV5g9UNCXEYV+lPx0CUX8egnUlxf7/EMjUTz1PsSsf8C7nOZDbVJQ==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "buffer": "^5.6.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.0.1",
+            "libp2p-tcp": "^0.14.1",
+            "multiaddr": "^7.4.3",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.13.11",
+            "peer-info": "^0.17.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^4.1.0"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         },
         "node-gyp-build": {
@@ -11625,18 +13435,6 @@
           "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
           "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
-        },
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
-          "dev": true,
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
-            "varint": "^5.0.0"
-          }
         },
         "secp256k1": {
           "version": "4.0.2",
@@ -11648,42 +13446,48 @@
             "node-addon-api": "^2.0.0",
             "node-gyp-build": "^4.2.0"
           }
+        },
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+          "dev": true
         }
       }
     },
     "libp2p-tcp": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.15.1.tgz",
-      "integrity": "sha512-alvgZ3lSNUyiz4vJOqvm6RpMQN9d17gSJa+VT+2pYLGf82o8pX3QvyhltMkBG7u9I+qZAkD6L27s8o0h38dpOg==",
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.14.6.tgz",
+      "integrity": "sha512-DeOdaH5QGVMKZflJmZq3dSWROxzD/YU1MFDxfi+DT4JVMcxfVMd+SpVEPMyk2wyA28H4AdGIRsH78yPjlFIyZQ==",
       "dev": true,
       "requires": {
         "abortable-iterator": "^3.0.0",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "libp2p-utils": "^0.2.0",
-        "mafmt": "^8.0.0",
-        "multiaddr": "^8.0.0",
+        "libp2p-utils": "^0.1.2",
+        "mafmt": "^7.1.0",
+        "multiaddr": "^7.5.0",
         "stream-to-it": "^0.2.2"
       }
     },
     "libp2p-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.2.0.tgz",
-      "integrity": "sha512-tZmqu27SULiIvfV+RZg5WOomxXIqM/SEd9FwKuirYTHHU1eet2bLzVQBhigatrdyQxebqi8GVnwbKmqdRElgCA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.1.3.tgz",
+      "integrity": "sha512-ApiQu45O+wTArSuAA8I0FR+CRf9lqoVTR1iGqSPx57x3iCzAtf3uKEOFxUDkgdWCnhpo04VKr2TLzxEYvkxd/w==",
       "dev": true,
       "requires": {
         "abortable-iterator": "^3.0.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.3",
         "ip-address": "^6.1.0",
-        "multiaddr": "^8.0.0"
+        "multiaddr": "^7.5.0"
       }
     },
     "libp2p-webrtc-peer": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-peer/-/libp2p-webrtc-peer-10.0.1.tgz",
-      "integrity": "sha512-Qi/YVrSI5sjU+iBvr1iAjGrakIEvzCS8S76v4q43jjlDb6Wj+S4OnFLH/uRlt7eLXcx4vlaI6huMzYrUAoopMg==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-peer/-/libp2p-webrtc-peer-9.7.2.tgz",
+      "integrity": "sha512-r/JzhV9EDYRU2bWHHUT5XsvmVaKb3wCESUbf8TyFBZ3iC11/43tYlK1gNyHvLpmsDLUC2XMRpHCsfxexnHUo0g==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1",
@@ -11695,49 +13499,80 @@
       }
     },
     "libp2p-webrtc-star": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.20.0.tgz",
-      "integrity": "sha512-qhchRoHp01AjHz3Gv1NJe41cL8H4HzAZNtg125aWZeqtB9fFFh1ZcuHpSqA2frNd2roPqNPpa8/eBRsgHBCRFw==",
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.18.6.tgz",
+      "integrity": "sha512-rrA0hQ7RwIW8rvwd2R9BnkmVVnH9jG98XaNykmlJ3At5jQOHcVYY13sqfEz8y0I5+5zbSd3xfvV9etBqyT8dRQ==",
       "dev": true,
       "requires": {
-        "@hapi/hapi": "^20.0.0",
-        "@hapi/inert": "^6.0.2",
+        "@hapi/hapi": "^18.4.0",
+        "@hapi/inert": "^5.2.2",
         "abortable-iterator": "^3.0.0",
+        "buffer": "^5.6.0",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "ipfs-utils": "^3.0.0",
+        "ipfs-utils": "^2.3.0",
         "it-pipe": "^1.0.1",
-        "libp2p-utils": "^0.2.0",
-        "libp2p-webrtc-peer": "^10.0.1",
-        "mafmt": "^8.0.0",
+        "libp2p-utils": "^0.1.0",
+        "libp2p-webrtc-peer": "^9.7.2",
+        "mafmt": "^7.0.1",
         "menoetius": "0.0.2",
         "minimist": "^1.2.0",
-        "multiaddr": "^8.0.0",
+        "multiaddr": "^7.1.0",
         "p-defer": "^3.0.0",
-        "peer-id": "^0.14.0",
+        "peer-id": "~0.13.12",
         "prom-client": "^12.0.0",
         "socket.io": "^2.3.0",
         "socket.io-client": "^2.3.0",
-        "stream-to-it": "^0.2.2",
-        "streaming-iterables": "^5.0.2"
+        "stream-to-it": "^0.2.0",
+        "streaming-iterables": "^4.1.0"
+      },
+      "dependencies": {
+        "ipfs-utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          }
+        },
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+          "dev": true
+        }
       }
     },
     "libp2p-websockets": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.14.0.tgz",
-      "integrity": "sha512-UeI0uqw2xYXFhImJucewG7fuL6hOR2tnSwlSAAxilyK0Z3Yya+GeVkqy7Vufj9ax3EWFx6lPO8mC3uBl30TkpA==",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.13.6.tgz",
+      "integrity": "sha512-3M2Fht4QtwIOrIxESJIFqsltmLGB2FQhtZXD4SxnLhBADqe3CYyrad+zsDjQRXlXU7u08l9lWM5gHWDtmqX7Aw==",
       "dev": true,
       "requires": {
         "abortable-iterator": "^3.0.0",
+        "buffer": "^5.5.0",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
         "it-ws": "^3.0.0",
-        "libp2p-utils": "^0.2.0",
-        "mafmt": "^8.0.0",
-        "multiaddr": "^8.0.0",
-        "multiaddr-to-uri": "^6.0.0",
+        "libp2p-utils": "~0.1.0",
+        "mafmt": "^7.0.0",
+        "multiaddr": "^7.1.0",
+        "multiaddr-to-uri": "^5.0.0",
         "p-timeout": "^3.2.0"
       }
     },
@@ -12078,12 +13913,12 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "mafmt": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-8.0.0.tgz",
-      "integrity": "sha512-MdaeaqZxjoYYWvlhr1GQ7sbsR3+L3s8QL0VtCuja+Iax3EhqAEgluSWPJezSDLyns7Ds4DGRyoq5+eIU7UDang==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
+      "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
       "dev": true,
       "requires": {
-        "multiaddr": "^8.0.0"
+        "multiaddr": "^7.3.0"
       }
     },
     "make-dir": {
@@ -12581,6 +14416,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -12811,12 +14647,12 @@
       }
     },
     "mongodb": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.1.tgz",
-      "integrity": "sha512-uH76Zzr5wPptnjEKJRQnwTsomtFOU/kQEU8a9hKHr2M7y9qVk7Q4Pkv0EQVp88742z9+RwvsdTw6dRjDZCNu1g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
+      "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
       "dev": true,
       "requires": {
-        "bl": "^2.2.0",
+        "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
@@ -12877,31 +14713,21 @@
       }
     },
     "mongodb-memory-server": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.6.7.tgz",
-      "integrity": "sha512-azRGr5csTAl0MCLR/amPCJrmV5TFwRcVtal56dHrPy1o2T8wZRc3AaJyukob8a/JP38JYa/pQnw1AQH7lFA2Cg==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.7.2.tgz",
+      "integrity": "sha512-isWtb1HM8z9wdLgOe4YZJjJGPRsDQfPh4X1cJfdUJcdRDl0A5Ullck6Yby2JYnTH9SFQaUePhi4RQnmQW98eNQ==",
       "dev": true,
       "requires": {
-        "mongodb-memory-server-core": "6.6.7"
+        "mongodb-memory-server-core": "6.7.2"
       }
     },
     "mongodb-memory-server-core": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.6.7.tgz",
-      "integrity": "sha512-21g2FpQdgqN3sFsj5lbGje1BhrSRGNHgz6gMAl8bvmdpRpoZErclkImVtjBXNHCNmCc1Dxr+EBvH11KaVE+9iQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.7.2.tgz",
+      "integrity": "sha512-SZ2Nw+4xZvRJ9r2q3mcE0rf8fz8u5FP1qvFydom6Q1VfDGR+rlunVPw/raw2JvuprbkxzpA1RQSiutnk4YLnCQ==",
       "dev": true,
       "requires": {
-        "@types/cross-spawn": "^6.0.2",
-        "@types/debug": "^4.1.5",
-        "@types/dedent": "^0.7.0",
-        "@types/find-cache-dir": "^3.2.0",
-        "@types/find-package-json": "^1.1.1",
-        "@types/lockfile": "^1.0.1",
-        "@types/md5-file": "^4.0.2",
-        "@types/mkdirp": "^1.0.1",
-        "@types/semver": "^7.3.3",
         "@types/tmp": "^0.2.0",
-        "@types/uuid": "^8.0.0",
         "camelcase": "^6.0.0",
         "cross-spawn": "^7.0.3",
         "debug": "^4.1.1",
@@ -12912,11 +14738,11 @@
         "lockfile": "^1.0.4",
         "md5-file": "^5.0.0",
         "mkdirp": "^1.0.4",
-        "mongodb": "^3.5.9",
+        "mongodb": "3.6.1",
         "semver": "^7.3.2",
         "tar-stream": "^2.1.3",
         "tmp": "^0.2.1",
-        "uuid": "^8.2.0",
+        "uuid": "8.3.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
@@ -12927,6 +14753,17 @@
           "dev": true,
           "requires": {
             "debug": "4"
+          }
+        },
+        "bl": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+          "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
           }
         },
         "camelcase": {
@@ -12998,6 +14835,21 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         },
+        "mongodb": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.1.tgz",
+          "integrity": "sha512-uH76Zzr5wPptnjEKJRQnwTsomtFOU/kQEU8a9hKHr2M7y9qVk7Q4Pkv0EQVp88742z9+RwvsdTw6dRjDZCNu1g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bl": "^2.2.0",
+            "bson": "^1.1.4",
+            "denque": "^1.4.1",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        },
         "p-locate": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -13022,11 +14874,55 @@
             "find-up": "^4.0.0"
           }
         },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true,
+              "optional": true
+            }
+          }
         },
         "uuid": {
           "version": "8.3.0",
@@ -13131,26 +15027,86 @@
       "dev": true
     },
     "multiaddr": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.0.0.tgz",
-      "integrity": "sha512-4OOyr0u0i4lvh9MY/mvuCNmH5eqoTamcnGeXz6umFGc0eaVQUGPDQNbp52YfFY92NlZ76pO6h4K2HkXsT5X43w==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+      "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
       "dev": true,
       "requires": {
-        "cids": "^1.0.0",
+        "buffer": "^5.5.0",
+        "cids": "~0.8.0",
         "class-is": "^1.1.0",
         "is-ip": "^3.1.0",
-        "multibase": "^3.0.0",
-        "uint8arrays": "^1.1.0",
+        "multibase": "^0.7.0",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        }
       }
     },
     "multiaddr-to-uri": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-6.0.0.tgz",
-      "integrity": "sha512-OjpkVHOXEmIKMO8WChzzQ7aZQcSQX8squxmvtDbRpy7/QNmJ3Z7jv6qyD74C28QtaeNie8O8ngW2AkeiMmKP7A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.1.0.tgz",
+      "integrity": "sha512-rIlMLkw3yk3RJmf2hxYYzeqPXz4Vx7C4M/hg7BVWhmksDW0rDVNMEyoVb0H1A+sh3deHOh5EAFK87XcW+mFimA==",
       "dev": true,
       "requires": {
-        "multiaddr": "^8.0.0"
+        "multiaddr": "^7.2.1"
       }
     },
     "multibase": {
@@ -13173,23 +15129,12 @@
       }
     },
     "multicodec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.0.tgz",
-      "integrity": "sha512-2SLsdTCXqOpUfoSHkTaVzxnjjl5fsSO283Idb9rAYgKGVu188NFP5KncuZ8Ifg8H2gc5GOi2rkuhLumqv9nweQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
       "requires": {
-        "uint8arrays": "1.0.0",
+        "buffer": "^5.6.0",
         "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "uint8arrays": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
-          "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
-          "requires": {
-            "multibase": "^3.0.0",
-            "web-encoding": "^1.0.2"
-          }
-        }
       }
     },
     "multihashes": {
@@ -13251,20 +15196,21 @@
       }
     },
     "multistream-select": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-1.0.0.tgz",
-      "integrity": "sha512-82riQ+qZ0RPY+KbRdeeKKQnFSBCVpUbZ15EniGU2nfwM8NdrpPIeUYXFw4a/pyprcNeRfMgLlG9aCh874p8nJg==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.15.2.tgz",
+      "integrity": "sha512-uoINaq+/9AkiUnyz0/bAZGqHUeWfRICuL9kqUnfuLPKwEr08HH0nbZFBsgfxP+1zzg22kabw8caNztE8ZSPncg==",
       "dev": true,
       "requires": {
         "bl": "^4.0.0",
+        "buffer": "^5.2.1",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "it-handshake": "^1.0.2",
+        "it-handshake": "^1.0.0",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.0.1",
+        "it-pushable": "^1.3.1",
         "it-reader": "^2.0.0",
-        "p-defer": "^3.0.0",
-        "uint8arrays": "^1.1.0"
+        "p-defer": "^3.0.0"
       }
     },
     "murmurhash3js": {
@@ -13640,9 +15586,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.60",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
-      "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+      "version": "1.1.61",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
+      "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
       "dev": true
     },
     "nodeify": {
@@ -14007,12 +15953,12 @@
       }
     },
     "orbit-db-io": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-io/-/orbit-db-io-0.3.0.tgz",
-      "integrity": "sha512-yWyhDR9vqw2+8tuOT+erKWkc9cL2QuemSVZgPjEm7nn+zkBzbacbfUdbgKtbtgUp8VDKhCzph2LfEEVhs6F5HA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-io/-/orbit-db-io-0.2.0.tgz",
+      "integrity": "sha512-wOunD4ZRgtTsAXJEu9NNEeJ8s98tZTtFlrLiI/ThuDKBy4AwpIvr+vMkzMD0DMSUTurRtK+xz7AfkP0nd9bcxQ==",
       "requires": {
-        "cids": "^1.0.0",
-        "ipld-dag-pb": "^0.20.0"
+        "cids": "^0.7.1",
+        "ipld-dag-pb": "^0.18.1"
       }
     },
     "orbit-db-keystore": {
@@ -14042,15 +15988,15 @@
       }
     },
     "orbit-db-test-utils": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/orbit-db-test-utils/-/orbit-db-test-utils-0.10.4.tgz",
-      "integrity": "sha512-Py4li92K6agbCqgROp+1C3HDrQt3u2aS8NMo2qytNhy+R5PeQZeyhBFeDXlI9QmAunxfoTuL+pr8avsR5y6RBg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/orbit-db-test-utils/-/orbit-db-test-utils-0.10.3.tgz",
+      "integrity": "sha512-Ci4s+zrxks6c7RG9ZuL1eZ5SoiLN3dXxtg9nSolAjy6pIiFr383x6GrbdOmPmm4yPYI6ckdaJZY+xgDI3MW5ew==",
       "dev": true,
       "requires": {
         "fruitdown": "^1.0.2",
         "go-ipfs": "^0.6.0",
-        "ipfs": "^0.50.1",
-        "ipfs-http-client": "~46.1.1",
+        "ipfs": "^0.49.0",
+        "ipfs-http-client": "~46.0.0",
         "ipfs-repo": "^6.0.3",
         "ipfsd-ctl": "^7.0.0",
         "js-combinatorics": "0.6.1",
@@ -14529,39 +16475,88 @@
       }
     },
     "peer-id": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.14.1.tgz",
-      "integrity": "sha512-QSEyJy9fEOtgB/NVrlJvlxO1Q8ZKpTLJ/HBVTj7bGJFGnm4febqSB/KlEL4WYm/fgvriHM+Wkfea3yD1Uacllw==",
+      "version": "0.13.13",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.13.tgz",
+      "integrity": "sha512-5FpBXN6PDTcHs51gkHWPf0OIQZAO3Z10i6lWc+GaoxTU4bQHtsoKFnhxoXo5Ze04JblpzIrtowkluLSCLP1WYg==",
       "dev": true,
       "requires": {
-        "cids": "^1.0.0",
+        "buffer": "^5.5.0",
+        "cids": "^0.8.0",
         "class-is": "^1.1.0",
-        "libp2p-crypto": "^0.18.0",
+        "libp2p-crypto": "^0.17.7",
         "minimist": "^1.2.5",
-        "multihashes": "^3.0.1",
-        "protons": "^2.0.0",
-        "uint8arrays": "^1.1.0"
+        "multihashes": "^1.0.1",
+        "protons": "^1.0.2"
       },
       "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
-          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^2.0.0",
+            "protons": "^1.2.1",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.1.0",
+            "uint8arrays": "^1.0.0",
             "ursa-optional": "^0.10.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         },
         "node-gyp-build": {
@@ -14569,18 +16564,6 @@
           "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
           "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
-        },
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
-          "dev": true,
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
-            "varint": "^5.0.0"
-          }
         },
         "secp256k1": {
           "version": "4.0.2",
@@ -14593,6 +16576,18 @@
             "node-gyp-build": "^4.2.0"
           }
         }
+      }
+    },
+    "peer-info": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.17.5.tgz",
+      "integrity": "sha512-ebbbnvdCnb0onWuW+QNXO4KvLPuQ+kih3zezhov2uxHqA6VLbtzMUyQ06IHtwYLr50AYYWyBOSn17g4zEBsFpw==",
+      "dev": true,
+      "requires": {
+        "mafmt": "^7.1.0",
+        "multiaddr": "^7.3.0",
+        "peer-id": "~0.13.2",
+        "unique-by": "^1.0.0"
       }
     },
     "pem-jwk": {
@@ -14629,94 +16624,36 @@
       "dev": true
     },
     "pino": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.5.1.tgz",
-      "integrity": "sha512-76+RUhQkqjUD4AtQcSfEzh6vlsjXmoWZK5gg+2d70aCLXZTbo4/5js4I9rN1Xk6z1h2/7pnOFX10G4c2T4qNiA==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
+      "integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
       "dev": true,
       "requires": {
         "fast-redact": "^2.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
         "pino-std-serializers": "^2.4.2",
-        "quick-format-unescaped": "^4.0.1",
-        "sonic-boom": "^1.0.2"
+        "quick-format-unescaped": "^3.0.3",
+        "sonic-boom": "^0.7.5"
       }
     },
     "pino-pretty": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.2.0.tgz",
-      "integrity": "sha512-CBFLgxMj/cJOANqZs+Xcjdgi1v40TJP3xMTkSN2xuOvX+03uAAHXf9SEU+1DHu/1kw44H2c31VYCImx0QewQ6w==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-3.6.1.tgz",
+      "integrity": "sha512-S3bal+Yd313OEaPijbf7V+jPxVaTaRO5RQX8S/Mwdtb/8+JOgo1KolDeJTfMDTU2/k6+MHvEbxv+T1ZRfGlnjA==",
       "dev": true,
       "requires": {
-        "@hapi/bourne": "^2.0.0",
+        "@hapi/bourne": "^1.3.2",
         "args": "^5.0.1",
-        "chalk": "^4.0.0",
+        "chalk": "^2.4.2",
         "dateformat": "^3.0.3",
         "fast-safe-stringify": "^2.0.7",
         "jmespath": "^0.15.0",
         "joycon": "^2.2.5",
         "pump": "^3.0.0",
-        "readable-stream": "^3.6.0",
+        "readable-stream": "^3.4.0",
         "split2": "^3.1.1",
-        "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+        "strip-json-comments": "^3.0.1"
       }
     },
     "pino-std-serializers": {
@@ -14948,9 +16885,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
-      "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
       "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -14963,15 +16900,15 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
         "long": "^4.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.16",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.16.tgz",
-          "integrity": "sha512-dJ9vXxJ8MEwzNn4GkoAGauejhXoKuJyYKegsA6Af25ZpEDXomeVXt5HUWUNVHk5UN7+U0f6ghC6otwt+7PdSDg==",
+          "version": "10.17.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.31.tgz",
+          "integrity": "sha512-AiazLSnsm7GfTxr08GrqeqMxygR/yV78RDk5gaw+S7pOP70BIqUbTFl9vZRyUC/XubcwIqkiiHxbJNFAGvSoOw==",
           "dev": true
         }
       }
@@ -15141,9 +17078,9 @@
       "dev": true
     },
     "quick-format-unescaped": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==",
       "dev": true
     },
     "rabin-wasm": {
@@ -15580,7 +17517,8 @@
     "reset": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/reset/-/reset-0.1.0.tgz",
-      "integrity": "sha1-n8cxQXGZWubLC35YsGznUir0uvs="
+      "integrity": "sha1-n8cxQXGZWubLC35YsGznUir0uvs=",
+      "dev": true
     },
     "resolve": {
       "version": "1.17.0",
@@ -15728,6 +17666,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/run/-/run-1.4.0.tgz",
       "integrity": "sha1-4X2ekEOrL+F3dsspnhI3848LT/o=",
+      "dev": true,
       "requires": {
         "minimatch": "*"
       }
@@ -15754,9 +17693,9 @@
       }
     },
     "rxjs": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-      "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -16236,9 +18175,9 @@
       }
     },
     "sonic-boom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.1.0.tgz",
-      "integrity": "sha512-JyOf+Xt7GBN4tAic/DD1Bitw6OMgSHAnswhPeOiLpfRoSjPNjEIi73UF3OxHzhSNn9WavxGuCZzprFCGFSNwog==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
+      "integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
       "dev": true,
       "requires": {
         "atomic-sleep": "^1.0.0",
@@ -16935,12 +18874,12 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-      "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
       "dev": true,
       "requires": {
-        "bl": "^4.0.1",
+        "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
@@ -17492,6 +19431,12 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
+    "unique-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
+      "integrity": "sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0=",
+      "dev": true
+    },
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -17671,13 +19616,13 @@
       }
     },
     "uri-to-multiaddr": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-4.0.0.tgz",
-      "integrity": "sha512-6zQ1uBlE+F//46CBA3lx3vBMhybSvdGJqgNyQPobSDsWGrDDdmJM/f95GPaswXAGFlRHPqOjrGKT11IcKmIfaA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-3.0.2.tgz",
+      "integrity": "sha512-I2AO1Y/3hUI7KfHiB6Py64lZ02jAB+hqlMVBzDRn4u6d85x+7tJhRwGzdKEYn8/1kDBtWFZVkHvgepF7Z+C1og==",
       "dev": true,
       "requires": {
         "is-ip": "^3.1.0",
-        "multiaddr": "^8.0.0"
+        "multiaddr": "^7.2.1"
       }
     },
     "urix": {
@@ -17799,12 +19744,21 @@
       "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
     "varint-decoder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-1.0.0.tgz",
-      "integrity": "sha512-JkOvdztASWGUAsXshCFHrB9f6AgR2Q8W08CEyJ+43b1qtFocmI8Sp1R/M0E/hDOY2FzVIqk63tOYLgDYWuJ7IQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-0.4.0.tgz",
+      "integrity": "sha512-1TGstvah6UbxTJCKMNV9eqR3u8lP7R3zmF52/sXQGyUYbHhh5HxW2dMEGADkuboqrCgOgheBn+z02YvN4bYGFg==",
       "dev": true,
       "requires": {
+        "is-buffer": "^2.0.4",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
       }
     },
     "varuint-bitcoin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-store",
-  "version": "4.0.0",
+  "version": "3.5.0",
   "description": "Base class for orbit-db data stores",
   "main": "src/Store.js",
   "scripts": {
@@ -18,7 +18,7 @@
     "url": "https://github.com/orbitdb/orbit-db-store"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "author": "Haad",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-store",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "description": "Base class for orbit-db data stores",
   "main": "src/Store.js",
   "scripts": {
@@ -26,7 +26,7 @@
     "ipfs-log": "~4.6.4",
     "it-to-stream": "^0.1.2",
     "logplease": "^1.2.14",
-    "orbit-db-io": "~0.3.0",
+    "orbit-db-io": "~0.2.0",
     "p-each-series": "^2.1.0",
     "p-map": "^4.0.0",
     "p-queue": "^6.6.1",
@@ -53,7 +53,7 @@
     "orbit-db-identity-provider": "~0.3.1",
     "orbit-db-keystore": "~0.3.5",
     "orbit-db-storage-adapter": "^0.5.3",
-    "orbit-db-test-utils": "^0.10.4",
+    "orbit-db-test-utils": "0.10.3",
     "rimraf": "^3.0.0",
     "standard": "^14.0.2",
     "webpack": "^4.44.1",


### PR DESCRIPTION
Since the later version of js-ipfs don't require streams as input to `add`, we can remove those and save ourselves some hassle. What do we think?