### PR TITLE
Fix replication progress callbacks

### DIFF
--- a/src/Replicator.js
+++ b/src/Replicator.js
@@ -143,7 +143,7 @@ class Replicator {
     // Notify the Store that we made progress
     const onProgressCallback = (entry) => {
       this._fetched[entry.hash] = true
-      if (this.onReplicationQueued) {
+      if (this.onReplicationProgress) {
         this.onReplicationProgress(entry)
       }
     }

--- a/src/Store.js
+++ b/src/Store.js
@@ -95,7 +95,8 @@ class Store {
         const previousProgress = this.replicationStatus.progress
         const previousMax = this.replicationStatus.max
         this._recalculateReplicationStatus(entry.clock.time)
-        if (this.replicationStatus.progress > previousProgress ||
+        if (this._oplog.length + 1 > this.replicationStatus.progress ||
+          this.replicationStatus.progress > previousProgress ||
           this.replicationStatus.max > previousMax) {
           this.events.emit('replicate.progress', this.address.toString(), entry.hash, entry, this.replicationStatus.progress, this.replicationStatus.max)
         }


### PR DESCRIPTION
This PR fixes a bug where `replicate.progress` wasn't emitted correctly when a log has concurrent ops.