### PR TITLE
patch error when closing during replication

### DIFF
--- a/src/Replicator.js
+++ b/src/Replicator.js
@@ -130,7 +130,9 @@ class Replicator {
 
   async stop () {
     // Clear the task queue
+    this._q.pause()
     this._q.clear()
+    await this._q.onIdle()
     // Reset internal caches
     this._logs = []
     this._fetching = {}

--- a/src/Store.js
+++ b/src/Store.js
@@ -184,8 +184,6 @@ class Store {
   }
 
   async close () {
-    this._oplog = null
-
     // Stop the Replicator
     await this._replicator.stop()
 
@@ -218,6 +216,8 @@ class Store {
     for (const event in this.events._events) {
       this.events.removeAllListeners(event)
     }
+
+    this._oplog = null
 
     // Database is now closed
     // TODO: afaik we don't use 'closed' event anymore,


### PR DESCRIPTION
- Store: `this._oplog = null` statement in .close moved toward end of method
- Replicator: `.stop` method now pauses and empties queued replication and waits for processing replication to complete 